### PR TITLE
Flesh out README in top directory of repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If you find some problem or have a question about tutorials and scripts in this 
 
 # How to get involved
 
-In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.md) in that directory has a table describing the tutorials, and information about how to contribute new material.
+In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.rst) in that directory has a table describing the tutorials, and information about how to contribute new material.
 
 # Questions?
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The [DC2-production repository](https://github.com/LSSTDESC/DC2-production) incl
 
 If you find some problem or have a question about tutorials and scripts in this repository, please ask by [opening an issue](https://github.com/LSSTDESC/DC2-analysis/issues).
 
+# License, credit
+
+This repository has a BSD 3-clause license (see LICENSE).
+
+The tutorials in the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) all indicate at what date they were last verified to run for the specific dataset that is used throughout the tutorial.  Additional contributions to the repository will include similar information, so that the state of a given piece of code can be clearly identified by users.
+
+If you make use of the notebooks in this repository for your research, please give a link to this repository and an acknowledgement of the author(s) of the notebook.
+
 # How to get involved
 
 In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.rst) in that directory has a table describing the tutorials.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # DC2-analysis
-General analysis tools for the DC2 Data Set.
+
+The repository contains general analysis scripts for the DC2 simulated dataset.  Project-specific work can be done in separate repositories, but some analysis tasks will be generally useful, and the relevant scripts and notebooks can be included here for more general consumption.
+
+# Links
+
+The [DC2-production repository](https://github.com/LSSTDESC/DC2-production) includes documents, discussion, and scripts related to the production and validation of DC2.  Please go there for more information.
+
+If you find some problem or have a question about tutorials and scripts in this repository, please ask by [opening an issue](https://github.com/LSSTDESC/DC2-analysis/issues).
+
+# How to get involved
+
+In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.md) in that directory has a table describing the tutorials, and information about how to contribute new material.
+
+# Questions?
+
+If the links above don't do the job, please [open an issue](https://github.com/LSSTDESC/DC2-analysis/issues) with your question.  Alternatively, the #desc-dc2-users channel on the LSSTC slack is a good place to talk with others who are analyzing DC2 data.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The repository contains general analysis scripts for the DC2 simulated dataset. 
 
 # Links
 
-The [DC2-production repository](https://github.com/LSSTDESC/DC2-production) includes documents, discussion, and scripts related to the production and validation of DC2.  Please go there for more information.
+The [DC2-production repository](https://github.com/LSSTDESC/DC2-production) includes documents, discussion, and scripts related to the production and validation of DC2.  Please go there for more information about DC2.
 
 If you find some problem or have a question about tutorials and scripts in this repository, please ask by [opening an issue](https://github.com/LSSTDESC/DC2-analysis/issues).
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ If you find some problem or have a question about tutorials and scripts in this 
 
 # How to get involved
 
-In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.rst) in that directory has a table describing the tutorials, and information about how to contribute new material.
+In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.rst) in that directory has a table describing the tutorials.
+
+TBD: Something needs to be said here about the contributed directory once it exists and has a README that says how to contribute new material, but there is nothing to link to yet.
 
 # Questions?
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 The repository contains general analysis scripts for the DC2 simulated dataset.  Project-specific work can be done in separate repositories, but some analysis tasks will be generally useful, and the relevant scripts and notebooks can be included here for more general consumption.
 
-# Links
+## Links
 
 The [DC2-production repository](https://github.com/LSSTDESC/DC2-production) includes documents, discussion, and scripts related to the production and validation of DC2.  Please go there for more information about DC2.
 
 If you find some problem or have a question about tutorials and scripts in this repository, please ask by [opening an issue](https://github.com/LSSTDESC/DC2-analysis/issues).
 
-# License, credit
+## License, credit
 
 This repository has a BSD 3-clause license (see LICENSE).
 
@@ -16,12 +16,12 @@ The tutorials in the [tutorials directory](https://github.com/LSSTDESC/DC2-analy
 
 If you make use of the notebooks in this repository for your research, please give a link to this repository and an acknowledgement of the author(s) of the notebook.
 
-# How to get involved
+## How to get involved
 
 In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.rst) in that directory has a table describing the tutorials.
 
 New scripts and notebooks can be added in the [contributed directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/contributed).  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/contributed/README.md) has a full description of how to do so.
 
-# Questions?
+## Questions?
 
 If the links above don't do the job, please [open an issue](https://github.com/LSSTDESC/DC2-analysis/issues) with your question.  Alternatively, the #desc-dc2-users channel on the LSSTC slack is a good place to talk with others who are analyzing DC2 data.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you find some problem or have a question about tutorials and scripts in this 
 
 In the [tutorials directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials) you can find a set of well-documented tutorials that show how to access and use DC2 data in a variety of ways.  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/tutorials/README.rst) in that directory has a table describing the tutorials.
 
-TBD: Something needs to be said here about the contributed directory once it exists and has a README that says how to contribute new material, but there is nothing to link to yet.
+New scripts and notebooks can be added in the [contributed directory](https://github.com/LSSTDESC/DC2-analysis/tree/master/contributed).  The [README](https://github.com/LSSTDESC/DC2-analysis/tree/master/contributed/README.md) has a full description of how to do so.
 
 # Questions?
 


### PR DESCRIPTION
This PR addresses part of issue #1 by fleshing out the README in the top directory of this repository.  It's still fairly basic but probably sufficient given that it can link to the subdirectory READMEs for more info.

In #3 we were discussing a `contributed` directory that will have a README Yao is putting together about how to contribute material, but the directory doesn't exist yet, so right now there is a note that linking to that directory and its README is TBD.
