### PR TITLE
add tutorial for accessing variable and transient objects in truth 1.2

### DIFF
--- a/tutorials/README.rst
+++ b/tutorials/README.rst
@@ -115,7 +115,7 @@ Notes on how to contribute more notebooks, and how the rendering is made, are at
      - `Yao-Yuan Mao <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao>`_
 
 
-   * - Truth Catalog with GCG
+   * - Truth Catalog with GCR
      - Example of accessing DC2 truth catalog with GCR
      - `ipynb <truth_gcr_intro.ipynb>`_,
        `rendered <https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/truth_gcr_intro.nbconvert.ipynb>`_
@@ -124,6 +124,18 @@ Notes on how to contribute more notebooks, and how the rendering is made, are at
           :target: https://github.com/LSSTDESC/DC2-analysis/blob/rendered/tutorials/log/truth_gcr_intro.log
 
      - `Scott Daniel <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@danielsf>`_
+
+
+   * - Truth Catalog with GCR: variables and transients
+     - Example of accessing variables and transient objects in the truth catalog with GCR
+     - `ipynb <truth_gcr_variables.ipynb>`_,
+       `rendered <https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/truth_gcr_variables.nbconvert.ipynb>`_
+
+       .. image:: https://github.com/LSSTDESC/DC2-analysis/blob/rendered/tutorials/log/truth_gcr_variables.svg
+          :target: https://github.com/LSSTDESC/DC2-analysis/blob/rendered/tutorials/log/truth_gcr_variables.log
+
+     - `Yao-Yuan Mao <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao>`_, 
+       `Scott Daniel <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@danielsf>`_
 
 
    * - Extragalactic catalog with GCR: redshift distributions

--- a/tutorials/truth_gcr_variables.ipynb
+++ b/tutorials/truth_gcr_variables.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Accessing variable and transient objects in the truth catalog\n",
+    "\n",
+    "**Notebook owner**: Yao-Yuan Mao [@yymao](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao).\n",
+    "\n",
+    "**Last Run:** 2018-10-17\n",
+    "\n",
+    "**Learning Objectives:** Use GCR to load summary table and light curves of variable and transient objects in the truth catalogs\n",
+    "\n",
+    "**Notes:** \n",
+    "- Variable and transient objects are **not** available in truth catalog 1.1\n",
+    "- To run this notebook, follow the instructions to setup Jupyter-dev at NERSC: https://confluence.slac.stanford.edu/x/1_ubDQ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import packages and methods that will be used in this notebook\n",
+    "\n",
+    "import healpy as hp\n",
+    "import numpy as np\n",
+    "import GCRCatalogs\n",
+    "import matplotlib\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary catalog\n",
+    "\n",
+    "First, we'll load the **summary catalog** (`sc`). The summary catalog is just a simple table that contains the coordinates, types, and id of the objects. \n",
+    "\n",
+    "The `filters` and `native_filters` options work just like how they work for the static object catalog (see the `truth_gcr_intro` tutorial notebook). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc = GCRCatalogs.load_catalog('dc2_truth_run1.2_variable_summary')\n",
+    "sc.list_all_quantities(include_native=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's now plot the locations of supernova and AGNs on the sky"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hp.mollview(np.ones(hp.nside2npix(2)), title='', cmap='Greys', min=0.9, max=1.5, cbar=None) # to get an empty sky map\n",
+    "\n",
+    "data = sc.get_quantities(['ra', 'dec'], native_filters=['sn == 1'])\n",
+    "hp.projscatter(data['ra'], data['dec'], lonlat=True, s=1)\n",
+    "\n",
+    "data = sc.get_quantities(['ra', 'dec'], native_filters=['agn == 1'])\n",
+    "hp.projscatter(data['ra'], data['dec'], lonlat=True, s=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## light curve catalog\n",
+    "\n",
+    "The way to access light curve catalog (`lc`) is a bit different.\n",
+    "\n",
+    "The data returned by the reader are the light curve tables, which have 5 columns: `uniqueId`, `obshistid`, `mjd`, `filter`, `mag`; and the `filters` option would work on any of these columns.\n",
+    "\n",
+    "However, the `native_filters` option works differently. They would be imposed on the columns of the \"summary catalog\" we mentioned above, so that one can for example select SNs from a certain RA ranges. \n",
+    "\n",
+    "Another difference is that, when `return_iterator` is turned on, the reader will iterator over the objects (i.e., returns one light curve table per objects). \n",
+    "\n",
+    "It's probably easier to illustrate this by an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lc = GCRCatalogs.load_catalog('dc2_truth_run1.2_variable_lightcurve')\n",
+    "lc.list_all_quantities(include_native=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot 3 supernova"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_plotted = 0\n",
+    "for q in lc.get_quantities(['mjd', 'mag'], filters=['filter == 3'], native_filters=['sn == 1', 'ra > 40'], return_iterator=True):\n",
+    "    if len(q['mjd']) >= 20:\n",
+    "        plt.plot(q['mjd'], q['mag'], '.-')\n",
+    "        n_plotted += 1\n",
+    "    if n_plotted >= 3:\n",
+    "        break\n",
+    "plt.ylim(29, 24)\n",
+    "plt.xlabel('MJD')\n",
+    "plt.ylabel('$i$ [mag]')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "desc-stack",
+   "language": "python",
+   "name": "desc-stack"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a new tutorial for accessing variable and transient objects in truth 1.2, mostly just following the example I gave in https://github.com/LSSTDESC/gcr-catalogs/pull/207#issue-220795147

This PR fixes #21.  