### PR TITLE
use desc-python kernel for truth catalog tutorials

### DIFF
--- a/tutorials/truth_gcr_intro.ipynb
+++ b/tutorials/truth_gcr_intro.ipynb
@@ -28,7 +28,7 @@
     "import healpy\n",
     "import numpy as np\n",
     "import GCRCatalogs\n",
-    "from lsst.sims.utils import angularSeparation\n",
+    "from astropy.coordinates import SkyCoord\n",
     "import matplotlib\n",
     "%matplotlib inline\n",
     "import matplotlib.pyplot as plt"
@@ -119,8 +119,11 @@
     "def filter_on_healpix(hp):\n",
     "    return np.array([hh in list_of_healpix for hh in hp])\n",
     "\n",
+    "def angularSeparation(ra, dec, center_ra, center_dec):\n",
+    "    return SkyCoord(ra, dec, unit='deg').separation(SkyCoord(center_ra, center_dec, unit='deg')).deg\n",
+    "\n",
     "def filter_on_dist(ra, dec):\n",
-    "    return angularSeparation(ra, dec, center_ra, center_dec)<radius"
+    "    return angularSeparation(ra, dec, center_ra, center_dec) < radius"
    ]
   },
   {
@@ -203,9 +206,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-stack",
+   "display_name": "desc-python",
    "language": "python",
-   "name": "desc-stack"
+   "name": "desc-python"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/truth_gcr_variables.ipynb
+++ b/tutorials/truth_gcr_variables.ipynb
@@ -138,9 +138,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-stack",
+   "display_name": "desc-python",
    "language": "python",
-   "name": "desc-stack"
+   "name": "desc-python"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
The truth catalog tutorials do not actually need the full DM stack. This PR switches their kernels to `desc-python`.