### PR TITLE
Bug fixes to some tutorial notebooks

### DIFF
--- a/tutorials/dm_butler_lensing_cuts.ipynb
+++ b/tutorials/dm_butler_lensing_cuts.ipynb
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "base_mask = ~(np.isnan(data['i_modelfit_CModel_flux'])\n",
+    "base_mask = ~(np.isnan(data['i_modelfit_CModel_instFlux'])\n",
     "         | np.isnan(data['ext_shapeHSM_HsmShapeRegauss_resolution'])\n",
     "         | np.isnan(data['ext_shapeHSM_HsmShapeRegauss_e1']))\n",
     "data = data[base_mask]\n",

--- a/tutorials/matching_stack.ipynb
+++ b/tutorials/matching_stack.ipynb
@@ -42,6 +42,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# to allow local import when using desc-stack kernel\n",
+    "import sys\n",
+    "sys.path.insert(0, '')\n",
+    "\n",
     "from utils.fieldRotator import FieldRotator"
    ]
   },
@@ -525,7 +529,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -20,8 +20,9 @@
     "  3. Load both the DC2 Run1.1p catalog and a selection from the HSC Public Data Release XMM field.\n",
     "  4. Directly access the coadd images to investigate suspicious objects.\n",
     "\n",
-    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC"
-   ]
+    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC\n",	    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC"
+    "\n",	
+    "__Other notes__: This notebook uses the [LSST DM stack](https://pipelines.lsst.io/) (see on the top right corner that we are using the `desc-stack` kernel)"   ]
   },
   {
    "cell_type": "markdown",

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -181,14 +181,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import healpy as hp\n",
+    "\n",
+    "import sys\n",
+    "sys.path.insert(0, '') # hack to make local import work with desc-stack kernel\n",
+    "from utils.cic import binned_statistic  # Import an efficient alternative to binned_statistic_2d, defined in utils/cic.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "import healpy as hp\n",
-    "from utils.cic import binned_statistic  # Import an efficient alternative to binned_statistic_2d, defined in utils/cic.py\n",
-    "\n",
     "def depth_map_snr (ra, dec, mags, snr,snr_threshold=10,nside=2048):\n",
     "    \"\"\"\n",
     "    Constructs a depth map on a healpix grid for a given SNR threshold.\n",
@@ -317,6 +327,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# a quick hack to make the new stack backward compatabie \n",
+    "import sys\n",
+    "try:\n",
+    "    import lsst.obs.lsst.phosim\n",
+    "except ImportError:\n",
+    "    print('[WARNING] You are using an older kernel. Log in to cori.nersc.gov and run\\n\\n/global/common/software/lsst/common/miniconda/kernels/setup.sh')\n",
+    "else:\n",
+    "    sys.modules['lsst.obs.lsstCam.lsstCamMapper'] = lsst.obs.lsst.phosim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# current available runs\n",
+    "REPOS = {\n",
+    "    '1.1p': '/global/cscratch1/sd/desc/DC2/data/Run1.1p/output',\n",
+    "    '1.2p': '/global/cscratch1/sd/desc/DC2/data/Run1.2p/rerun/coadd-all2',\n",
+    "    '1.2i': '/global/cscratch1/sd/desc/DC2/data/Run1.2i/rerun/multiband',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -389,7 +429,7 @@
    "outputs": [],
    "source": [
     "# Create an instance of the data butler for the run 1.1p data repository\n",
-    "repo = '/global/projecta/projectdirs/lsst/global/in2p3/Run1.1/output'\n",
+    "repo = REPOS['1.1p']\n",
     "butler = dafPersist.Butler(repo)\n",
     "\n",
     "plt.figure(figsize=(15,15));\n",
@@ -532,9 +572,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-python",
+   "display_name": "desc-stack",
    "language": "python",
-   "name": "desc-python"
+   "name": "desc-stack"
   },
   "language_info": {
    "codemirror_mode": {
@@ -546,7 +586,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -20,9 +20,10 @@
     "  3. Load both the DC2 Run1.1p catalog and a selection from the HSC Public Data Release XMM field.\n",
     "  4. Directly access the coadd images to investigate suspicious objects.\n",
     "\n",
-    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC\n",	    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC"
-    "\n",	
-    "__Other notes__: This notebook uses the [LSST DM stack](https://pipelines.lsst.io/) (see on the top right corner that we are using the `desc-stack` kernel)"   ]
+    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC\n",
+    "\n",
+    "__Other notes__: This notebook uses the [LSST DM stack](https://pipelines.lsst.io/) (see on the top right corner that we are using the `desc-stack` kernel)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -20,9 +20,7 @@
     "  3. Load both the DC2 Run1.1p catalog and a selection from the HSC Public Data Release XMM field.\n",
     "  4. Directly access the coadd images to investigate suspicious objects.\n",
     "\n",
-    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC\n",
-    "\n",
-    "__Other notes__: This notebook uses the [LSST DM stack](https://pipelines.lsst.io/) (see on the top right corner that we are using the `desc-stack` kernel)"
+    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC"
    ]
   },
   {
@@ -534,9 +532,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-stack",
+   "display_name": "desc-python",
    "language": "python",
-   "name": "desc-stack"
+   "name": "desc-python"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/object_gcr_3_challenges.ipynb
+++ b/tutorials/object_gcr_3_challenges.ipynb
@@ -437,9 +437,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-stack",
+   "display_name": "desc-python",
    "language": "python",
-   "name": "desc-stack"
+   "name": "desc-python"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Some bugs were introduced after the `desc-stack` kernel is updated. This PR fixes those bugs by
- changing the kernels of one notebook that do not use stack to `desc-python`,
- allowing local import for two notebooks that uses `desc-stack`.

I would appreciate a quick review from someone for this to be ready in time for the hackurDC2 announcement, thanks! (cc @reneehlozek)