### PR TITLE
rename coadd catalog -> object catalog

### DIFF
--- a/tutorials/object_gcr_1_intro.ipynb
+++ b/tutorials/object_gcr_1_intro.ipynb
@@ -4,17 +4,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DC2 Coadd Run1.1p GCR tutorial -- Part I: GCR access\n",
+    "# DC2 Object Catalog Run1.1p GCR tutorial -- Part I: GCR access\n",
     "\n",
     "Owners: **Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL), Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez)**  \n",
     "Last Verifed to Run: **2018-07-20**\n",
     "\n",
-    "This notebook will illustrate the basics of accessing the merged coadd catalogs through the Generic Catalog Reader (GCR, https://github.com/yymao/generic-catalog-reader) as well as how to select useful samples of stars/galaxies from the DM outputs.\n",
+    "This notebook will illustrate the basics of accessing the merged, DPDD-like, object catalogs through the Generic Catalog Reader (GCR, https://github.com/yymao/generic-catalog-reader) as well as how to select useful samples of stars/galaxies from the DM outputs.\n",
     "\n",
     "__Learning objectives__:\n",
     "\n",
     "After going through this notebook, you should be able to:\n",
-    "  1. Load and efficiently access a DC2 coadd catalog with the GCR\n",
+    "  1. Load and efficiently access a DC2 object catalog with the GCR\n",
     "  2. Understand and have references for the catalog schema\n",
     "  3. Apply cuts to the catalog using GCR functionalities\n",
     "  4. Have an example of quality cuts and simple star/galaxy separation cut\n",
@@ -41,10 +41,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Accessing the coadd catalog with the GCR\n",
+    "## Accessing the object catalog with the GCR\n",
     "\n",
     "The [GCRCatalogs](https://github.com/LSSTDESC/gcr-catalogs) package is a DESC project which aims at gathering in one convenient location various simulation/data catalogs made available to the collaboration.  \n",
-    "In this section, we illustrate how to use this tool to access the coadd catalogs from DC2 Run1.1p."
+    "In this section, we illustrate how to use this tool to access the object catalogs from DC2 Run1.1p."
    ]
   },
   {
@@ -54,22 +54,22 @@
    "outputs": [],
    "source": [
     "import GCRCatalogs\n",
-    "# Load the coadd catalog\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_coadd_run1.1p')"
+    "# Load the object catalog\n",
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A significant numbers of catalogs besides the DC2 coadd are already available, use `sorted(GCRCatalogs.get_available_catalogs(False))` to see a full list and visit the [DC2 Data Product](https://confluence.slac.stanford.edu/display/LSSTDESC/DC2+Data+Product+Overview) page to see all the DC2 related catalogs."
+    "A significant numbers of catalogs besides the DC2 object catalogs are already available, use `sorted(GCRCatalogs.get_available_catalogs(False))` to see a full list and visit the [DC2 Data Product](https://confluence.slac.stanford.edu/display/LSSTDESC/DC2+Data+Product+Overview) page to see all the DC2 related catalogs."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### DC2 Coadd catalog Schema\n",
+    "### DC2 object catalog Schema\n",
     "\n",
     "\n",
     "To see the quantities available in the catalog, you can use the following:"
@@ -133,7 +133,7 @@
     "\n",
     "You can learn more about how to make such a plot of the tract and patches [here](Plotting_the_Run1.1p_skymap.ipynb)\n",
     "\n",
-    "The **GCR coadd catalog preserves this structure of the data** so that any particular quantity can be accessed on a tract/patch bases. The tracts available in the catalog can be listed using the following command:"
+    "The **GCR object catalog preserves this structure of the data** so that any particular quantity can be accessed on a tract/patch bases. The tracts available in the catalog can be listed using the following command:"
    ]
   },
   {
@@ -158,7 +158,7 @@
    "metadata": {},
    "source": [
     "GCR provides the following `native_filters` mechanism, which you can use to speed up data access if you only need a certain chunks of the dataset.\n",
-    "For the coadd catalog, the chunks are broken into `tract` and `patch`, and hence those are the `native_filters` you can use:"
+    "For the object catalog, the chunks are broken into `tract` and `patch`, and hence those are the `native_filters` you can use:"
    ]
   },
   {
@@ -248,7 +248,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to make accessing chunks of data convenient to the user, the `catalog.get_quantities` also provides the option to [return an iterator](https://yymao.github.io/generic-catalog-reader/#GCR.BaseGenericCatalog.get_quantities). This allows you to only read and work on one piece of data at a time while looping through the entire catalog. Remember that catalogs can be very large and might not fit in memory if you try to load the entire catalog at once. In the DC2 coadd catalog, as we follow the DM structure of data, the catalog will iterate over `tract` and `patch` when using `return_iterator`. \n",
+    "In order to make accessing chunks of data convenient to the user, the `catalog.get_quantities` also provides the option to [return an iterator](https://yymao.github.io/generic-catalog-reader/#GCR.BaseGenericCatalog.get_quantities). This allows you to only read and work on one piece of data at a time while looping through the entire catalog. Remember that catalogs can be very large and might not fit in memory if you try to load the entire catalog at once. In the DC2 object catalog, as we follow the DM structure of data, the catalog will iterate over `tract` and `patch` when using `return_iterator`. \n",
     "\n",
     "You can find more general information about iterators [here](https://stackoverflow.com/questions/3294889/iterating-over-dictionaries-using-for-loops)."
    ]
@@ -473,7 +473,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more information about the stellar locus from models and in Run1.1p see the [DC2 Coadd Run1.1p direct access -- color-color stellar locus](DC2%20Coadd%20Run1.1p%20direct%20access%20--%20color-color%20stellar%20locus.ipynb) tutorial\n",
+    "For more information about the stellar locus from models and in Run1.1p see the [DC2 Object Catalog Run1.1p direct access -- color-color stellar locus](object_pandas_stellar_locus.ipynb) tutorial\n",
     "\n",
     "Q: What else can you do to improve the star selection?"
    ]
@@ -482,7 +482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__If you want to see more go to [Part II](DC2%20Coadd%20Run1.1p%20GCR%20tutorial%20--%20Part%20II%3A%20Lensing%20Cuts.ipynb)__"
+    "__If you want to see more go to [Part II](object_gcr_2_lensing_cuts.ipynb)__"
    ]
   },
   {

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -4,13 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DC2 Coadd Run1.1p GCR tutorial -- Part II: Lensing Cuts\n",
+    "# DC2 Object Catalog Run1.1p GCR tutorial -- Part II: Lensing Cuts\n",
     "\n",
     "\n",
     "Owners: **Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL), Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez)**  \n",
     "Last Verified to Run: **2018-07-20**\n",
     "\n",
-    "This notebook is the second part of the tutorial [here](DC2%20Coadd%20Run1.1p%20GCR%20tutorial%20--%20Part%20I%3A%20GCR%20Access.ipynb). Here, we present more advanced features of the merged coadd catalogs through the Generic Catalog Reader [GCR](https://github.com/yymao/generic-catalog-reader) and build a lensing sample which we compare to the published [HSC Y1 sample](https://hsc-release.mtk.nao.ac.jp/doc/). The final goal is to show how the different filtering mechanisms, features of `GCR`, and the samples presented here can be useful for your science.\n",
+    "This notebook is the second part of the tutorial ([Part I here](object_gcr_1_intro.ipynb)). Here, we present more advanced features of the merged, DPDD-like, object catalogs through the Generic Catalog Reader [GCR](https://github.com/yymao/generic-catalog-reader) and build a lensing sample which we compare to the published [HSC Y1 sample](https://hsc-release.mtk.nao.ac.jp/doc/). The final goal is to show how the different filtering mechanisms, features of `GCR`, and the samples presented here can be useful for your science.\n",
     "\n",
     "__Learning objectives__:\n",
     "\n",
@@ -31,7 +31,7 @@
    "source": [
     "## Selecting a useful sample of galaxies: lensing cuts from HSC DR1\n",
     "\n",
-    "In this notebook, we will build step by step a sample of galaxies from the DC2 run1.1p coadd catalog, and compare it to an equivalent sample built from the HSC DR1 catalog. See more info on [Aihara et al. 2018](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)\n",
+    "In this notebook, we will build step by step a sample of galaxies from the DC2 run1.1p object catalog, and compare it to an equivalent sample built from the HSC DR1 catalog. See more info on [Aihara et al. 2018](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)\n",
     "\n",
     "### Sample selection\n",
     "\n",
@@ -63,8 +63,8 @@
    "source": [
     "import GCRCatalogs\n",
     "from GCR import GCRQuery\n",
-    "# Load the coadd catalog\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_coadd_run1.1p')"
+    "# Load the object catalog\n",
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')"
    ]
   },
   {
@@ -535,7 +535,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "__If you want, you can check out [Part III: Challenges](DC2%20Coadd%20Run1.1p%20GCR%20tutorial%20--%20Part%20III%3A%20Guided%20Challenges.ipynb)!__"
+    "__If you want, you can check out [Part III: Challenges](object_gcr_3_challenges.ipynb)!__"
    ]
   },
   {

--- a/tutorials/object_gcr_3_challenges.ipynb
+++ b/tutorials/object_gcr_3_challenges.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DC2 Coadd Run1.1p GCR tutorial -- Part III: Guided Challenges\n",
+    "# DC2 Object Catalog Run1.1p GCR tutorial -- Part III: Guided Challenges\n",
     "\n",
     "Owners: **Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez), Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL)**  \n",
     "Last Run: **2018-07-25**\n",
     "\n",
-    "This notebook is the last in the Run1.1p GCR series ([Part I](DC2%20Coadd%20Run1.1p%20GCR%20tutorial%20--%20Part%20I%3A%20GCR%20Access.ipynb), [Part II](DC2%20Coadd%20Run1.1p%20GCR%20tutorial%20--%20Part%20II%3A%20Lensing%20Cuts.ipynb)). Here, we propose some challenges for you as science use cases of the coadd catalogs. We will provide a solution here but you are encouraged to create your own!\n",
+    "This notebook is the last in the Run1.1p object catalog with GCR series ([Part I](object_gcr_1_intro.ipynb), [Part II](object_gcr_2_lensing_cuts.ipynb)). Here, we propose some challenges for you as science use cases of the object catalogs. We will provide a solution here but you are encouraged to create your own!\n",
     "\n",
     "\n",
     "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC"
@@ -97,8 +97,8 @@
    "source": [
     "import GCRCatalogs\n",
     "from GCR import GCRQuery\n",
-    "# Load the coadd catalog\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_coadd_run1.1p')"
+    "# Load the object catalog\n",
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')"
    ]
   },
   {
@@ -238,7 +238,7 @@
     "import GCRCatalogs\n",
     "from GCR import GCRQuery\n",
     "\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_coadd_run1.1p')\n",
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')\n",
     "\n",
     "filters=[\n",
     "    # Add the required filters\n",

--- a/tutorials/object_pandas_stellar_locus.ipynb
+++ b/tutorials/object_pandas_stellar_locus.ipynb
@@ -8,7 +8,7 @@
     }
    },
    "source": [
-    "# Looking at the \"Coadd Catalogs\": merged tract-patch catalogs in DC2 Run 1.1p\n",
+    "# Looking at the \"Object Catalogs\": merged tract-patch catalogs in DC2 Run 1.1p\n",
     "<br>Owner: **Michael Wood-Vasey** ([@wmwv](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@wmwv))\n",
     "<br>Last Verified to Run: **2018-07-24**"
    ]
@@ -18,11 +18,11 @@
    "metadata": {},
    "source": [
     "### Purpose:\n",
-    "Demonstrate reading a static-sky catalog from photometry on the coadd images based on the static coadd catalog.  Shows the example of plotting a color-color stellar locus against the data to demonstrate some basic use of the magnitudes and extendedness columns.\n",
+    "Demonstrate reading a static-sky object catalog from photometry on the coadd images based on the static coadd catalog.  Shows the example of plotting a color-color stellar locus against the data to demonstrate some basic use of the magnitudes and extendedness columns.\n",
     "\n",
     "### Learning Objectives:\n",
     "After working through and studying this Notebook you should be able to\n",
-    "1. Read in the DC2 Run 1.1p coadd catalog directly from the flat files.\n",
+    "1. Read in the DC2 Run 1.1p object catalog directly from the flat files.\n",
     "2. Construct a color-color diagram for stars\n",
     "3. Overplot a stellar locus model\n",
     "\n",
@@ -70,14 +70,14 @@
    },
    "outputs": [],
    "source": [
-    "merged_tract_data_dir = '/global/projecta/projectdirs/lsst/global/in2p3/Run1.1/coadd_catalog/'"
+    "merged_tract_data_dir = '/global/projecta/projectdirs/lsst/global/in2p3/Run1.1/object_catalog/'"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the LSST Data Management processing, the sky is divided into tracts.  Each tract is divided into patches (8x8 in this processing).  The coadd catalog files are saved by tract.  These files are HDF5 files which are divided into group keys by patch.\n",
+    "In the LSST Data Management processing, the sky is divided into tracts.  Each tract is divided into patches (8x8 in this processing).  The object catalog files are saved by tract.  These files are HDF5 files which are divided into group keys by patch.\n",
     "\n",
     "For more information see: [How to the Run 1.1p skymap](Plotting_the_Run1.1p_skymap.ipynb)"
    ]
@@ -133,7 +133,7 @@
    },
    "outputs": [],
    "source": [
-    "print(len(df), \"coadd objects\")"
+    "print(len(df), \"objects\")"
    ]
   },
   {
@@ -152,7 +152,7 @@
     "plt.ylim(-1, +2)\n",
     "plt.xlabel('g-r')\n",
     "plt.ylabel('r-i')\n",
-    "plt.title('Color-color diagram of all objects in one tract of coadd catalogs')"
+    "plt.title('Color-color diagram of all objects in one tract of object catalogs')"
    ]
   },
   {
@@ -516,10 +516,9 @@
     "* The catalogs supporting DC2 are in:\n",
     "https://github.com/LSSTDESC/gcr-catalogs\n",
     "\n",
-    "See the \"DC2 Coadd Run1.1p GCR tutorial\" series!",
-    "\n",
+    "See the \"DC2 object Run1.1p GCR tutorial\" series!\n",
     "For an example of using the GCR to do work similar to the agove:\n",
-    "[DC2 Coadd Run1.1p GCR tutorial -- Part I: GCR Access.ipynb](DC2%20Coadd%20Run1.1p%20GCR%20tutorial%20--%20Part%20I%3A%20GCR%20Access.ipynb)"
+    "[DC2 object Run1.1p GCR tutorial -- Part I: GCR Access.ipynb](object_gcr_1_intro.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
This PR updates four existing tutorial notebooks that use the object catalogs, to make the terminology consistent (i.e., renaming coadd catalog -> object catalog). 

This PR fixes #32