### PR TITLE
update 1.1p to 1.2i in object_gcr_1_intro

### DIFF
--- a/tutorials/object_gcr_1_intro.ipynb
+++ b/tutorials/object_gcr_1_intro.ipynb
@@ -343,7 +343,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Admittedly, this plot is a little underwhelming, these quality cuts only remove a very small number of objects. This is due in part to the fact that Run 1.2i ran from inSim outputs with essentially perfect Instrument Signature Removal (ISR). Also, Run 1.2i coadds only have a limited number of exposures, but defects will add up as the coadds get deeper.\n",
+    "Admittedly, this plot is a little underwhelming, these quality cuts only remove a very small number of objects. This is due in part to the fact that Run 1.2i ran from imSim outputs with essentially perfect Instrument Signature Removal (ISR). Also, Run 1.2i coadds only have a limited number of exposures, but defects will add up as the coadds get deeper.\n",
     "\n",
     "To get a sense of the impact of these quality flags on real data, we can load with the GCR a tract of the HSC PDR1 data ([Aihara et al (2018)](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)) which is made available on cori. Note that this HSC catalog follows the same schema as Run 1.2i. This tract is part of the XMM subfield of HSC (find out more about the HSC data release [here](https://hsc-release.mtk.nao.ac.jp/doc/) and [here](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)).\n",
     "\n",

--- a/tutorials/object_gcr_1_intro.ipynb
+++ b/tutorials/object_gcr_1_intro.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DC2 Object Catalog Run1.1p GCR tutorial -- Part I: GCR access\n",
+    "# DC2 Object Catalog Run1.2i GCR tutorial -- Part I: GCR access\n",
     "\n",
     "Owners: **Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL), Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez)**  \n",
-    "Last Verifed to Run: **2018-07-20**\n",
+    "Last Verifed to Run: **2018-11-17** (by @yymao)\n",
     "\n",
     "This notebook will illustrate the basics of accessing the DPDD-like object catalog, which contains the detected objects at the coadd level, through the Generic Catalog Reader (GCR, https://github.com/yymao/generic-catalog-reader) as well as how to select useful samples of stars/galaxies from the DM outputs.\n",
     "\n",
@@ -44,7 +44,7 @@
     "## Accessing the object catalog with the GCR\n",
     "\n",
     "The [GCRCatalogs](https://github.com/LSSTDESC/gcr-catalogs) package is a DESC project which aims at gathering in one convenient location various simulation/data catalogs made available to the collaboration.  \n",
-    "In this section, we illustrate how to use this tool to access the object catalogs from DC2 Run1.1p."
+    "In this section, we illustrate how to use this tool to access the object catalogs from DC2 Run1.2i."
    ]
   },
   {
@@ -55,7 +55,7 @@
    "source": [
     "import GCRCatalogs\n",
     "# Load the object catalog\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')"
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.2i')"
    ]
   },
   {
@@ -88,7 +88,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The meaning of these fields is documented in the [SCHEMA.md](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-dc2-coadd-catalogs) file of the `gcr-catalog` repository.  \n",
+    "The meaning of these fields is documented in the [SCHEMA.md](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-dc2-coadd-catalogs) file of the `LSSTDESC/gcr-catalogs` repository.  \n",
     "As explained in that link, the values exposed here are not the native quantities produced by the Data Management stack, but instead this schema strives to follow the standard nomenclature of the LSST Data Products Definition Document [DPDD](http://ls.st/dpdd).\n",
     "\n",
     "The DPDD is an effort made by the LSST project to standardize the format of the official Data Release Products (DRP). While the native outputs of the DM stack are succeptible to change, the DPDD will be more stable. An early adoption of these conventions by the DESC will save time and energy down the road.\n",
@@ -124,7 +124,7 @@
    "source": [
     "### Accessing the data\n",
     "\n",
-    "While Run1.1p is still of manageable size, full DC2 will be much larger, accessing the whole data can be challenging. In order to access the data efficiently, it is important to understand how it is physically stored and how to access it, one piece at the time. \n",
+    "While Run1.2i is still of manageable size, full DC2 will be much larger, accessing the whole data can be challenging. In order to access the data efficiently, it is important to understand how it is physically stored and how to access it, one piece at the time. \n",
     "\n",
     "\n",
     "The coadds produced by the DM stack are structured in terms of large `tracts` and smaller `patches`, illustrated here for DC2:\n",
@@ -343,9 +343,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Admittedly, this plot is a little underwhelming, these quality cuts only remove a very small number of objects. This is due in part to the fact that Run 1.1p ran from phosim outputs with essentially perfect Istrument Signature Removal (ISR). Also, Run 1.1p coadds only have a limited number of exposures, but defects will add up as the coadds get deeper.\n",
+    "Admittedly, this plot is a little underwhelming, these quality cuts only remove a very small number of objects. This is due in part to the fact that Run 1.2i ran from inSim outputs with essentially perfect Instrument Signature Removal (ISR). Also, Run 1.2i coadds only have a limited number of exposures, but defects will add up as the coadds get deeper.\n",
     "\n",
-    "To get a sense of the impact of these quality flags on real data, we can load with the GCR a tract of the HSC PDR1 data ([Aihara et al (2018)](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)) which is made available on cori. Note that this HSC catalog follows the same schema as Run 1.1p. This tract is part of the XMM subfield of HSC (find out more about the HSC data release [here](https://hsc-release.mtk.nao.ac.jp/doc/) and [here](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)).\n",
+    "To get a sense of the impact of these quality flags on real data, we can load with the GCR a tract of the HSC PDR1 data ([Aihara et al (2018)](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)) which is made available on cori. Note that this HSC catalog follows the same schema as Run 1.2i. This tract is part of the XMM subfield of HSC (find out more about the HSC data release [here](https://hsc-release.mtk.nao.ac.jp/doc/) and [here](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)).\n",
     "\n",
     "Let's load this catalog, and apply the same cuts:"
    ]
@@ -426,12 +426,9 @@
     "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
     "                       # and was not skipped by the deblender\n",
     "    GCRQuery('extendedness==0'),\n",
-    "    GCRQuery('g_modelfit_CModel_flux>0'),\n",
-    "    GCRQuery('g_modelfit_CModel_flux<1e16'),\n",
-    "    GCRQuery('r_modelfit_CModel_flux>0'),\n",
-    "    GCRQuery('r_modelfit_CModel_flux<1e16'),\n",
-    "    GCRQuery('i_modelfit_CModel_flux>0'),\n",
-    "    GCRQuery('i_modelfit_CModel_flux<1e16'),\n",
+    "    GCRQuery((np.isfinite, 'mag_g_cModel')),\n",
+    "    GCRQuery((np.isfinite, 'mag_r_cModel')),\n",
+    "    GCRQuery((np.isfinite, 'mag_i_cModel')),\n",
     "]\n",
     "\n",
     "quantities = ['mag_g_cModel', 'mag_r_cModel', 'mag_i_cModel']\n",
@@ -461,20 +458,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist2d(d['mag_g_cModel']-d['mag_r_cModel'],\n",
+    "plt.hexbin(d['mag_g_cModel']-d['mag_r_cModel'],\n",
     "           d['mag_r_cModel']-d['mag_i_cModel'], \n",
-    "           bins=100,range=[(-1,2),(-1,2)]);\n",
+    "           bins='log', extent=[-1,2,-1,2]);\n",
     "plt.xlabel('$g-r$')\n",
     "plt.ylabel('$r-i$')\n",
-    "plt.colorbar(label='Number of objects')"
+    "plt.colorbar(label='log(Number of objects)')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more information about the stellar locus from models and in Run1.1p see the [DC2 Object Catalog Run1.1p direct access -- color-color stellar locus](object_pandas_stellar_locus.ipynb) tutorial\n",
-    "\n",
     "Q: What else can you do to improve the star selection?"
    ]
   },
@@ -484,13 +479,6 @@
    "source": [
     "__If you want to see more go to [Part II](object_gcr_2_lensing_cuts.ipynb)__"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -509,7 +497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the object catalog used in `object_gcr_1_intro` tutorial from 1.1p to 1.2i. 

Most changes are trivial. One important difference is that `g_modelfit_CModel_flux` is no longer available as a native quantity in 1.2i, so that corresponding filters have been updated in this PR. 

This PR partly addresses #19.