### PR TITLE
update 1.1p to 1.2i in matching_fof

### DIFF
--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -4,9 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Match truth and coadd catalogs for DC2 Run 1.1p\n",
+    "# Match truth and object catalogs for DC2 Run 1.2i\n",
     "Owner: Yao-Yuan Mao, Scott Daniel (with help from Anže Slosar, Bhairav Valera, HyeYun Park) <br>\n",
-    "Last Verified to Run: 2018-07-23\n",
+    "Last Verified to Run: 2018-11-17\n",
     "\n",
     "**Notes:**\n",
     "- Follow this [step-by-step guide](https://confluence.slac.stanford.edu/x/Xgg4Dg) if you don't know how to run this notebook.\n",
@@ -14,7 +14,7 @@
     "\n",
     "## Learning objectives\n",
     "After completing and studying this Notebook, you should be able to:\n",
-    "  1. Use GCR to load coadd catalog and truth catalog\n",
+    "  1. Use GCR to load object catalog and truth catalog\n",
     "  2. Use `filters` and `native_filters` appropriately\n",
     "  3. Use `add_quantity_modifier` and `get_quantity_modifier`\n",
     "  4. Use `FoFCatalogMatching` to do Friends-of-friends catalog matching\n",
@@ -50,8 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# load coadd catalog (for a single tract)\n",
-    "coadd_cat = GCRCatalogs.load_catalog('dc2_coadd_run1.1p_tract4850')"
+    "# load object catalog (for a single tract)\n",
+    "object_cat = GCRCatalogs.load_catalog('dc2_object_run1.2i_all_columns')"
    ]
   },
   {
@@ -60,16 +60,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's first visually inspect the footprint of one tract of the coadd catalog.\n",
+    "# Let's first visually inspect the footprint of one tract of the object catalog.\n",
     "# When `return_iterator` is turned on, the method `get_quantities` will return an \n",
     "# iterator, and each element in the iterator will be the quantities we requested in \n",
     "# different chunks of the dataset. \n",
     "\n",
-    "# For coadd catalogs, the different chunks happen to be different patches, \n",
+    "# For object catalogs, the different chunks happen to be different patches, \n",
     "# resulting in a different color for each patch in the scatter plot below.\n",
     "\n",
-    "for coadd_data in coadd_cat.get_quantities(['ra', 'dec'], return_iterator=True):\n",
-    "    plt.scatter(coadd_data['ra'], coadd_data['dec'], s=1, rasterized=True);\n",
+    "for object_data in object_cat.get_quantities(['ra', 'dec'], native_filters=['tract == 4850'], return_iterator=True):\n",
+    "    plt.scatter(object_data['ra'], object_data['dec'], s=1, rasterized=True);\n",
     "\n",
     "plt.xlabel('RA');\n",
     "plt.ylabel('Dec');"
@@ -115,7 +115,7 @@
    "outputs": [],
    "source": [
     "# let's add total ellipticity for later use (not needed for now)\n",
-    "coadd_cat.add_derived_quantity('shape_hsm_regauss_etot', np.hypot, 'ext_shapeHSM_HsmShapeRegauss_e1', 'ext_shapeHSM_HsmShapeRegauss_e2')"
+    "object_cat.add_derived_quantity('shape_hsm_regauss_etot', np.hypot, 'ext_shapeHSM_HsmShapeRegauss_e1', 'ext_shapeHSM_HsmShapeRegauss_e2')"
    ]
   },
   {
@@ -124,8 +124,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load ra and dec from coadd, using both of the filters we just defined. (why not also grab e1 and e2 for later use?)\n",
-    "coadd_data = coadd_cat.get_quantities(['ra', 'dec', 'mag_i', 'shape_hsm_regauss_etot'], filters=(coord_filters + mag_filters))"
+    "# Load ra and dec from object, using both of the filters we just defined.\n",
+    "object_data = object_cat.get_quantities(['ra', 'dec', 'mag_i', 'shape_hsm_regauss_etot'], filters=(coord_filters + mag_filters), native_filters=['tract == 4850'])"
    ]
   },
   {
@@ -136,8 +136,8 @@
    },
    "outputs": [],
    "source": [
-    "# Let's now turn to the truth catalog, turn of md5 sum check to save time\n",
-    "truth_cat = GCRCatalogs.load_catalog('dc2_truth_run1.1', {'md5': None})"
+    "# Let's now turn to the truth catalog\n",
+    "truth_cat = GCRCatalogs.load_catalog('dc2_truth_run1.2_static')"
    ]
   },
   {
@@ -159,18 +159,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# so we see there is not mag_i, but only mag_true_i (i.e., magnitude before lensing), and it maps to `i`\n",
-    "truth_cat.get_quantity_modifier('mag_true_i')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# so we see there is no mag_i, but only mag_true_i (i.e., magnitude before lensing)\n",
     "# to make our `mag_filters` work, let's define mag_i for the truth catalog\n",
-    "truth_cat.add_quantity_modifier('mag_i', 'i')"
+    "truth_cat.add_quantity_modifier('mag_i', truth_cat.get_quantity_modifier('mag_true_i'))"
    ]
   },
   {
@@ -202,7 +193,7 @@
     "# so we need to specify `catalog_len_getter` so that the code knows how to get the length of the catalog.\n",
     "\n",
     "results = FoFCatalogMatching.match(\n",
-    "    catalog_dict={'truth': truth_data, 'coadd': coadd_data},\n",
+    "    catalog_dict={'truth': truth_data, 'object': object_data},\n",
     "    linking_lengths=1.0,\n",
     "    catalog_len_getter=lambda x: len(x['ra']),\n",
     ")"
@@ -224,26 +215,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# now we want to count the number of truth and coadd objects *for each group*\n",
+    "# now we want to count the number of truth and object objects *for each group*\n",
     "# but instead of looping over groups, we can do this in a smart (and very fast) way\n",
     "\n",
-    "# first we need to know which rows are from the truth catalog and which are from the coadd\n",
+    "# first we need to know which rows are from the truth catalog and which are from the object\n",
     "truth_mask = results['catalog_key'] == 'truth'\n",
-    "coadd_mask = ~truth_mask\n",
+    "object_mask = ~truth_mask\n",
     "\n",
     "# then np.bincount will give up the number of id occurrences (like historgram but with integer input)\n",
     "n_groups = results['group_id'].max() + 1\n",
     "n_truth = np.bincount(results['group_id'][truth_mask], minlength=n_groups)\n",
-    "n_coadd = np.bincount(results['group_id'][coadd_mask], minlength=n_groups)\n",
+    "n_object = np.bincount(results['group_id'][object_mask], minlength=n_groups)\n",
     "\n",
-    "# now n_truth and n_coadd are the number of truth/coadd objects in each group\n",
-    "# we want to make a 2d histrogram of (n_truth, n_coadd). \n",
-    "n_max = max(n_truth.max(), n_coadd.max()) + 1\n",
-    "hist_2d = np.bincount(n_coadd * n_max + n_truth, minlength=n_max*n_max).reshape(n_max, n_max)\n",
+    "# now n_truth and n_object are the number of truth/object objects in each group\n",
+    "# we want to make a 2d histrogram of (n_truth, n_object). \n",
+    "n_max = max(n_truth.max(), n_object.max()) + 1\n",
+    "hist_2d = np.bincount(n_object * n_max + n_truth, minlength=n_max*n_max).reshape(n_max, n_max)\n",
     "\n",
     "plt.imshow(np.log10(hist_2d+1), extent=(-0.5, n_max-0.5, -0.5, n_max-0.5), origin='lower');\n",
     "plt.xlabel('Number of truth objects');\n",
-    "plt.ylabel('Number of coadd objects');\n",
+    "plt.ylabel('Number of object objects');\n",
     "plt.colorbar(label=r'$\\log(N_{\\rm groups} \\, + \\, 1)$');"
    ]
   },
@@ -253,14 +244,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's further inspect the objects in the groups that have 1-to-1 truth/coadd match.\n",
+    "# Let's further inspect the objects in the groups that have 1-to-1 truth/object match.\n",
     "\n",
-    "# first, let's find our the IDs of the groups that have 1-to-1 truth/coadd match:\n",
-    "one_to_one_group_mask = np.in1d(results['group_id'], np.flatnonzero((n_truth == 1) & (n_coadd == 1)))\n",
+    "# first, let's find our the IDs of the groups that have 1-to-1 truth/object match:\n",
+    "one_to_one_group_mask = np.in1d(results['group_id'], np.flatnonzero((n_truth == 1) & (n_object == 1)))\n",
     "\n",
-    "# and then we can find the row indices in the *original* truth/coadd catalogs for those 1-to-1 groups\n",
+    "# and then we can find the row indices in the *original* truth/object catalogs for those 1-to-1 groups\n",
     "truth_idx = results['row_index'][one_to_one_group_mask & truth_mask]\n",
-    "coadd_idx = results['row_index'][one_to_one_group_mask & coadd_mask]"
+    "object_idx = results['row_index'][one_to_one_group_mask & object_mask]"
    ]
   },
   {
@@ -270,11 +261,11 @@
    "outputs": [],
    "source": [
     "truth_sc = SkyCoord(truth_data['ra'][truth_idx], truth_data['dec'][truth_idx], unit=\"deg\")\n",
-    "coadd_sc = SkyCoord(coadd_data['ra'][coadd_idx], coadd_data['dec'][coadd_idx], unit=\"deg\")\n",
+    "object_sc = SkyCoord(object_data['ra'][object_idx], object_data['dec'][object_idx], unit=\"deg\")\n",
     "\n",
-    "delta_ra = (coadd_sc.ra.arcsec - truth_sc.ra.arcsec) * np.cos(np.deg2rad(0.5*(truth_sc.dec.deg + coadd_sc.dec.deg)))\n",
-    "delta_dec = coadd_sc.dec.arcsec - truth_sc.dec.arcsec\n",
-    "delta_arcsec = coadd_sc.separation(truth_sc).arcsec"
+    "delta_ra = (object_sc.ra.arcsec - truth_sc.ra.arcsec) * np.cos(np.deg2rad(0.5*(truth_sc.dec.deg + object_sc.dec.deg)))\n",
+    "delta_dec = object_sc.dec.arcsec - truth_sc.dec.arcsec\n",
+    "delta_arcsec = object_sc.separation(truth_sc).arcsec"
    ]
   },
   {
@@ -331,10 +322,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# convert truth_data and coadd_data to pandas dataframe and select the matched one\n",
+    "# convert truth_data and object_data to pandas dataframe and select the matched one\n",
     "truth_matched = pd.DataFrame(truth_data).iloc[truth_idx].reset_index(drop=True)\n",
-    "coadd_matched = pd.DataFrame(coadd_data).iloc[coadd_idx].reset_index(drop=True)\n",
-    "matched = pd.merge(truth_matched, coadd_matched, left_index=True, right_index=True, suffixes=('_truth', '_coadd'))"
+    "object_matched = pd.DataFrame(object_data).iloc[object_idx].reset_index(drop=True)\n",
+    "matched = pd.merge(truth_matched, object_matched, left_index=True, right_index=True, suffixes=('_truth', '_object'))"
    ]
   },
   {
@@ -355,7 +346,7 @@
    "outputs": [],
    "source": [
     "# First, load the extragalactic catalog that was used for this simulation (using _test to skip md5 check)\n",
-    "extragalactic_cat = GCRCatalogs.load_catalog('proto-dc2_v2.1.2_test')"
+    "extragalactic_cat = GCRCatalogs.load_catalog('proto-dc2_v3.0_test')"
    ]
   },
   {
@@ -411,7 +402,7 @@
     "plt.scatter(matched_gals['mag_i'], matched_gals['mag_i_extra'], s=1);\n",
     "lims = [14, 26]\n",
     "plt.plot(lims, lims, c='k', lw=0.5);\n",
-    "plt.xlabel('$i$ coadd');\n",
+    "plt.xlabel('$i$ object');\n",
     "plt.ylabel('$i$ extragalactic');\n",
     "plt.xlim(lims);\n",
     "plt.ylim(lims);"
@@ -428,18 +419,11 @@
     "plt.scatter(matched_gals['shape_hsm_regauss_etot'], matched_gals['ellipticity_true'], s=1);\n",
     "lims = [0, 1]\n",
     "plt.plot(lims, lims, c='k', lw=0.5);\n",
-    "plt.xlabel('ellipticity coadd');\n",
+    "plt.xlabel('ellipticity object');\n",
     "plt.ylabel('ellipticity extragalactic');\n",
     "plt.xlim(lims);\n",
     "plt.ylim(lims);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -458,7 +442,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,

--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Match truth and object catalogs for DC2 Run 1.2i\n",
     "Owner: Yao-Yuan Mao, Scott Daniel (with help from Anže Slosar, Bhairav Valera, HyeYun Park) <br>\n",
-    "Last Verified to Run: 2018-11-17\n",
+    "Last Verified to Run: 2018-11-19\n",
     "\n",
     "**Notes:**\n",
     "- Follow this [step-by-step guide](https://confluence.slac.stanford.edu/x/Xgg4Dg) if you don't know how to run this notebook.\n",
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "# Load ra and dec from object, using both of the filters we just defined.\n",
-    "object_data = object_cat.get_quantities(['ra', 'dec', 'mag_i', 'shape_hsm_regauss_etot'], filters=(coord_filters + mag_filters), native_filters=['tract == 4850'])"
+    "object_data = object_cat.get_quantities(['ra', 'dec', 'mag_i_cModel', 'shape_hsm_regauss_etot'], filters=(coord_filters + mag_filters), native_filters=['tract == 4850'])"
    ]
   },
   {
@@ -357,7 +357,7 @@
    "source": [
     "# load redshift and shear parameters from the extragalactic catalog, only for galaxise that are already in `matched_gals`\n",
     "extragalactic_data = extragalactic_cat.get_quantities(\n",
-    "    ['galaxy_id', 'mag_i', 'ellipticity_true', 'shear_1', 'shear_2'],\n",
+    "    ['galaxy_id', 'mag_i_lsst', 'ellipticity_true', 'shear_1', 'shear_2'],\n",
     "    filters=[(lambda x: np.in1d(x, matched_gals['object_id'].values, True), 'galaxy_id')]\n",
     ")"
    ]
@@ -369,7 +369,7 @@
    "outputs": [],
    "source": [
     "# merge extragalactic_data to matched_gals\n",
-    "matched_gals = pd.merge(matched_gals, pd.DataFrame(extragalactic_data), 'left', left_on='object_id', right_on='galaxy_id', suffixes=('', '_extra'))"
+    "matched_gals = pd.merge(matched_gals, pd.DataFrame(extragalactic_data), 'left', left_on='object_id', right_on='galaxy_id')"
    ]
   },
   {
@@ -399,11 +399,11 @@
    "source": [
     "# compare the magnitude\n",
     "plt.figure(figsize=(5,5));\n",
-    "plt.scatter(matched_gals['mag_i'], matched_gals['mag_i_extra'], s=1);\n",
-    "lims = [14, 26]\n",
+    "plt.scatter(matched_gals['mag_i_lsst'], matched_gals['mag_i_cModel'], s=1);\n",
+    "lims = [14, 25]\n",
     "plt.plot(lims, lims, c='k', lw=0.5);\n",
-    "plt.xlabel('$i$ object');\n",
-    "plt.ylabel('$i$ extragalactic');\n",
+    "plt.xlabel('extragalactic $i$-mag');\n",
+    "plt.ylabel('object $i$-mag (cModel)');\n",
     "plt.xlim(lims);\n",
     "plt.ylim(lims);"
    ]
@@ -416,11 +416,11 @@
    "source": [
     "# compare the ellipticity\n",
     "plt.figure(figsize=(5,5));\n",
-    "plt.scatter(matched_gals['shape_hsm_regauss_etot'], matched_gals['ellipticity_true'], s=1);\n",
+    "plt.scatter(matched_gals['ellipticity_true'], matched_gals['shape_hsm_regauss_etot'], s=1);\n",
     "lims = [0, 1]\n",
     "plt.plot(lims, lims, c='k', lw=0.5);\n",
-    "plt.xlabel('ellipticity object');\n",
-    "plt.ylabel('ellipticity extragalactic');\n",
+    "plt.xlabel('extragalactic ellipticity');\n",
+    "plt.ylabel('object ellipticity');\n",
     "plt.xlim(lims);\n",
     "plt.ylim(lims);"
    ]


### PR DESCRIPTION
This PR updates the `matching_fof` tutorial:
- object catalog from 1.1p to 1.2i
- truth catalog from 1.1 to 1.2
- extragalactic catalog (protoDC2) from 2.1.2 to 3.0
- "coadd" --> "object"

This PR partly addresses #19.