### PR TITLE
update 1.1p to 1.2i in object_gcr_2_lensing_cuts

### DIFF
--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -87,13 +87,13 @@
    "outputs": [],
    "source": [
     "basic_cuts = [\n",
-    "    GCRQuery('extendedness > 0'),    # Extended objects\n",
-    "    #GCRQuery('merge_measurement_i'), # Select objects for which the reference is the i-band\n",
+    "    GCRQuery('extendedness > 0'),     # Extended objects\n",
+    "    GCRQuery((np.isfinite, 'mag_i')), # Select objects that have i-band magnitudes\n",
     "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
     "                       # and was not skipped by the deblender\n",
-    "    ~GCRQuery('xy_flag'),                                        # Flag for bad centroid measurement\n",
-    "    ~GCRQuery('ext_shapeHSM_HsmShapeRegauss_flag'),              # Error code returned by shape measurement code\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_sigma')), # Shape measurement uncertainty should not be NaN\n",
+    "    GCRQuery('xy_flag == 0'),                                      # Flag for bad centroid measurement\n",
+    "    GCRQuery('ext_shapeHSM_HsmShapeRegauss_flag == 0'),            # Error code returned by shape measurement code\n",
+    "    GCRQuery((np.isfinite, 'ext_shapeHSM_HsmShapeRegauss_sigma')), # Shape measurement uncertainty should not be NaN\n",
     "]"
    ]
   },

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -117,8 +117,17 @@
     "# Adds the new derived column \n",
     "catalog.add_quantity_modifier('shape_hsm_regauss_etot', \n",
     "                              (np.hypot, 'ext_shapeHSM_HsmShapeRegauss_e1', 'ext_shapeHSM_HsmShapeRegauss_e2'), \n",
-    "                              overwrite=True)\n",
-    "\n",
+    "                              overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
     "# Define lensing cuts on galaxy properties \n",
     "properties_cuts = [\n",
     "    GCRQuery('snr_i_cModel > 10'),                              # SNR > 10\n",
@@ -164,7 +173,7 @@
    "metadata": {},
    "source": [
     "You can compare this plot to Fig 12. in [Mandelbaum et al. 2018](http://adsabs.harvard.edu/abs/2018PASJ...70S..25M):\n",
-    "<img src=\"assets/fig12_mandelbaum2017.png\">\n",
+    "<img src=\"https://github.com/LSSTDESC/DC2-analysis/raw/master/tutorials/assets/fig12_mandelbaum2017.png\">\n",
     "\n",
     "A quick visual comparison will highlight two things:\n",
     "\n",
@@ -292,8 +301,8 @@
    "outputs": [],
    "source": [
     "# Compute i-band depth maps for both surveys\n",
-    "m10map_dc2 = depth_map_snr(data_dc2['ra'],data_dc2['dec'],data_dc2['mag_i_cModel'], data_dc2['snr_i_cModel'])\n",
-    "m10map_hsc = depth_map_snr(data_hsc['ra'],data_hsc['dec'],data_hsc['mag_i_cModel'], data_hsc['snr_i_cModel'])\n",
+    "m10map_dc2 = depth_map_snr(data_dc2['ra'], data_dc2['dec'], data_dc2['mag_i_cModel'], data_dc2['snr_i_cModel'])\n",
+    "m10map_hsc = depth_map_snr(data_hsc['ra'], data_hsc['dec'], data_hsc['mag_i_cModel'], data_hsc['snr_i_cModel'])\n",
     "\n",
     "# Printing the median depth\n",
     "print(\"Run1.2i median i-band 10-sigma depth \", np.median(m10map_dc2[m10map_dc2 > 0]))\n",
@@ -326,7 +335,7 @@
    },
    "outputs": [],
    "source": [
-    "sample_cut = basic_cuts + properties_cuts + [GCRQuery('ext_shapeHSM_HsmShapeRegauss_resolution >= 0.98')]\n",
+    "sample_cut = basic_cuts + properties_cuts + ['ext_shapeHSM_HsmShapeRegauss_resolution >= 0.98']\n",
     "\n",
     "data = catalog.get_quantities(['ra', 'dec', 'mag_i_cModel', 'ext_shapeHSM_HsmShapeRegauss_resolution'], \n",
     "                              filters=sample_cut,\n",
@@ -429,19 +438,18 @@
    },
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(15,15));\n",
-    "for i, coord in enumerate(zip(data['ra'][:16], data['dec'][:16])):\n",
-    "    plt.subplot(4,4,i+1)\n",
+    "fig, ax = plt.subplots(4, 4, figsize=(15,15))\n",
     "\n",
+    "for ra, dec, ax_this in zip(data['ra'], data['dec'], ax.flat):\n",
     "    # Extract the cutout using the data butler\n",
-    "    cutout_image = cutout_coadd_ra_dec(butler, *coord);\n",
+    "    cutout_image = cutout_coadd_ra_dec(butler, ra, dec)\n",
     "    \n",
     "    # Plot the postage stamp on the same scales, with some arcsinh range compression \n",
-    "    plt.imshow(np.arcsinh(cutout_image.image.array), vmax=4, cmap='binary');\n",
+    "    ax_this.imshow(np.arcsinh(cutout_image.image.array), vmax=4, cmap='binary');\n",
     "    \n",
     "    # Let's add a crosshair to guide the eye\n",
-    "    plt.axhline(25, color='k',alpha=0.5)\n",
-    "    plt.axvline(25, color='k',alpha=0.5);"
+    "    ax_this.axhline(25, color='k', alpha=0.5);\n",
+    "    ax_this.axvline(25, color='k', alpha=0.5);"
    ]
   },
   {
@@ -463,9 +471,9 @@
    },
    "outputs": [],
    "source": [
-    "data = catalog.get_quantities(['blendedness'], \n",
-    "                              filters=sample_cut,\n",
-    "                              native_filters=['tract == 4849'])\n",
+    "data.update(catalog.get_quantities(['blendedness'], \n",
+    "                                   filters=sample_cut,\n",
+    "                                   native_filters=['tract == 4849']))\n",
     "\n",
     "data['blendedness'][:16]"
    ]

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "\n",
     "Owners: **Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL), Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez)**  \n",
-    "Last Verified to Run: **2018-11-17** (by @yymao)\n",
+    "Last Verified to Run: **2018-11-19** (by @yymao)\n",
     "\n",
     "This notebook is the second part of the tutorial ([Part I here](object_gcr_1_intro.ipynb)). Here, we present more advanced features of the  DPDD-like object catalog, which contains the detected objects at the coadd level, through the Generic Catalog Reader [GCR](https://github.com/yymao/generic-catalog-reader) and build a lensing sample which we compare to the published [HSC Y1 sample](https://hsc-release.mtk.nao.ac.jp/doc/). The final goal is to show how the different filtering mechanisms, features of `GCR`, and the samples presented here can be useful for your science.\n",
     "\n",
@@ -43,17 +43,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# need to use this PR https://github.com/LSSTDESC/gcr-catalogs/pull/226\n",
-    "import sys\n",
-    "sys.path.insert(0, '/global/homes/y/yymao/desc/gcr-catalogs/')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -75,7 +64,7 @@
     "import GCRCatalogs\n",
     "from GCR import GCRQuery\n",
     "# Load the object catalog\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.2i_all_columns', {'schema_filename': 'X'})"
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.2i_all_columns')"
    ]
   },
   {
@@ -313,7 +302,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And now we see the difference between the two samples, HSC is much deeper. This is partly due to the fact that run1.1p was interrupted mid-run so it doesn't reach the full depth of DC2."
+    "And now we see the difference between the two samples, HSC is much deeper. (For the case of Run 1.1p, this is partly due to the fact that it was interrupted mid-run so it doesn't reach the full depth of DC2.)"
    ]
   },
   {
@@ -370,7 +359,7 @@
     "\n",
     "# Please check the DC2 Postage Stamps tutorial for all the details of how this works\n",
     "def cutout_coadd_ra_dec(butler, ra, dec, filt='i', datasetType='deepCoadd', \n",
-    "                                  skymap=None, cutoutSideLength=50, **kwargs):\n",
+    "                        skymap=None, cutoutSideLength=50, **kwargs):\n",
     "    \"\"\"Produce a cutout from a coadd at the given ra,dec coordinates\n",
     "    \n",
     "\n",

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -4,11 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DC2 Object Catalog Run1.1p GCR tutorial -- Part II: Lensing Cuts\n",
+    "# DC2 Object Catalog Run1.2i GCR tutorial -- Part II: Lensing Cuts\n",
     "\n",
     "\n",
     "Owners: **Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL), Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez)**  \n",
-    "Last Verified to Run: **2018-07-20**\n",
+    "Last Verified to Run: **2018-11-17** (by @yymao)\n",
     "\n",
     "This notebook is the second part of the tutorial ([Part I here](object_gcr_1_intro.ipynb)). Here, we present more advanced features of the  DPDD-like object catalog, which contains the detected objects at the coadd level, through the Generic Catalog Reader [GCR](https://github.com/yymao/generic-catalog-reader) and build a lensing sample which we compare to the published [HSC Y1 sample](https://hsc-release.mtk.nao.ac.jp/doc/). The final goal is to show how the different filtering mechanisms, features of `GCR`, and the samples presented here can be useful for your science.\n",
     "\n",
@@ -17,7 +17,7 @@
     "After going through this notebook, you should be able to:\n",
     "  1. Select a clean sample of galaxies for weak lensing.\n",
     "  2. Compute a depth map for a given SNR threshold.\n",
-    "  3. Load both the DC2 Run1.1p catalog and a selection from the HSC Public Data Release XMM field.\n",
+    "  3. Load both the DC2 Run1.2i catalog and a selection from the HSC Public Data Release XMM field.\n",
     "  4. Directly access the coadd images to investigate suspicious objects.\n",
     "\n",
     "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC\n",
@@ -31,13 +31,24 @@
    "source": [
     "## Selecting a useful sample of galaxies: lensing cuts from HSC DR1\n",
     "\n",
-    "In this notebook, we will build step by step a sample of galaxies from the DC2 run1.1p object catalog, and compare it to an equivalent sample built from the HSC DR1 catalog. See more info on [Aihara et al. 2018](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)\n",
+    "In this notebook, we will build step by step a sample of galaxies from the DC2 run1.2i object catalog, and compare it to an equivalent sample built from the HSC DR1 catalog. See more info on [Aihara et al. 2018](http://adsabs.harvard.edu/abs/2018PASJ...70S...8A)\n",
     "\n",
     "### Sample selection\n",
     "\n",
     "We will start from a set of basic sanity cuts that will select extended objects and reject problematic sources, including those for which shape measurement has failed.\n",
     "\n",
     "One subtlety is that shape measurement is only run for the *reference band*, which is most of the time the i-band, but not always, we will further restrict the sample to objects for which we have i-band shapes using the `merge_measurement_i` flag."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# need to use this PR https://github.com/LSSTDESC/gcr-catalogs/pull/226\n",
+    "import sys\n",
+    "sys.path.insert(0, '/global/homes/y/yymao/desc/gcr-catalogs/')"
    ]
   },
   {
@@ -64,7 +75,7 @@
     "import GCRCatalogs\n",
     "from GCR import GCRQuery\n",
     "# Load the object catalog\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')"
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.2i_all_columns', {'schema_filename': 'X'})"
    ]
   },
   {
@@ -77,13 +88,12 @@
    "source": [
     "basic_cuts = [\n",
     "    GCRQuery('extendedness > 0'),    # Extended objects\n",
-    "    GCRQuery('merge_measurement_i'), # Select objects for which the reference is the i-band\n",
-    "    \n",
+    "    #GCRQuery('merge_measurement_i'), # Select objects for which the reference is the i-band\n",
     "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
     "                       # and was not skipped by the deblender\n",
-    "    ~GCRQuery('xy_flag'),                                       # Flag for bad centroid measurement\n",
-    "    ~GCRQuery('ext_shapeHSM_HsmShapeRegauss_flag'),             # Error code returned by shape measurement code\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_sigma')) # Shape measurement uncertainty should not be NaN\n",
+    "    ~GCRQuery('xy_flag'),                                        # Flag for bad centroid measurement\n",
+    "    ~GCRQuery('ext_shapeHSM_HsmShapeRegauss_flag'),              # Error code returned by shape measurement code\n",
+    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_sigma')), # Shape measurement uncertainty should not be NaN\n",
     "]"
    ]
   },
@@ -115,14 +125,14 @@
     "    GCRQuery('mag_i_cModel < 24.5'),                            # cModel imag brighter than 24.5\n",
     "    GCRQuery('ext_shapeHSM_HsmShapeRegauss_resolution >= 0.3'), # Sufficiently resolved galaxies compared to PSF\n",
     "    GCRQuery('shape_hsm_regauss_etot < 2'),                     # Total distortion in reasonable range\n",
-    "    GCRQuery('ext_shapeHSM_HsmShapeRegauss_sigma <= 0.4')       # Shape measurement errors reasonable\n",
+    "    GCRQuery('ext_shapeHSM_HsmShapeRegauss_sigma <= 0.4'),      # Shape measurement errors reasonable\n",
     "]\n",
     "\n",
     "# We can now extract our lensing sample \n",
     "quantities = ['mag_i_cModel', 'snr_i_cModel', 'shape_hsm_regauss_etot', 'ext_shapeHSM_HsmShapeRegauss_resolution']\n",
     "data_basic = catalog.get_quantities(quantities, \n",
-    "                           filters=basic_cuts + properties_cuts, \n",
-    "                           native_filters=['tract == 4849'])"
+    "                                    filters=basic_cuts+properties_cuts, \n",
+    "                                    native_filters=['tract == 4849'])"
    ]
   },
   {
@@ -135,17 +145,17 @@
    "source": [
     "plt.figure(figsize=(10,10))\n",
     "plt.subplot(221)\n",
-    "plt.hist(data_basic['ext_shapeHSM_HsmShapeRegauss_resolution'], 100, range=[0,1],normed=True);\n",
+    "plt.hist(data_basic['ext_shapeHSM_HsmShapeRegauss_resolution'], 100, range=[0,1], density=True);\n",
     "plt.xlabel('i-band resolution')\n",
     "plt.xlim()\n",
     "plt.subplot(222)\n",
-    "plt.hist(data_basic['snr_i_cModel'], 100, range=[0,100],normed=True)\n",
+    "plt.hist(data_basic['snr_i_cModel'], 100, range=[0,100], density=True)\n",
     "plt.xlabel('i-band cmodel S/N')\n",
     "plt.subplot(223)\n",
-    "plt.hist(data_basic['mag_i_cModel'], 100, range=[20,25],normed=True);\n",
+    "plt.hist(data_basic['mag_i_cModel'], 100, range=[20,25], density=True);\n",
     "plt.xlabel('i-band cmodel mag')\n",
     "plt.subplot(224)\n",
-    "plt.hist(data_basic['shape_hsm_regauss_etot'],100,normed=True);\n",
+    "plt.hist(data_basic['shape_hsm_regauss_etot'],100, density=True);\n",
     "plt.xlabel('Ellipticity magniture |e|');"
    ]
   },
@@ -175,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One obvious reason why we would be missing some faint galaxies is if DC2 run1.1p is shallower than HSC. We will test this here by measuring the depths of both Run1.1p and the HSC DR1 XMM field. More generally, it is also a concern for most science analysis to have spatially uniform sampled data, which can be checked by looking at the depth of the sample.  \n",
+    "One obvious reason why we would be missing some faint galaxies is if DC2 run1.2i is shallower than HSC. We will test this here by measuring the depths of both Run1.2i and the HSC DR1 XMM field. More generally, it is also a concern for most science analysis to have spatially uniform sampled data, which can be checked by looking at the depth of the sample.  \n",
     "\n",
     "There are several ways to do this, in this case, we are going to check what's the magnitude which has a median SNR closest to 10, the SNR cut of our lensing sample."
    ]
@@ -255,7 +265,7 @@
    "source": [
     "quantities = ['ra', 'dec', 'mag_i_cModel', 'snr_i_cModel', 'ext_shapeHSM_HsmShapeRegauss_resolution']\n",
     "\n",
-    "# Data from DC2 run1.1p\n",
+    "# Data from DC2 run1.2i\n",
     "data_dc2 = catalog.get_quantities(quantities, \n",
     "                                  filters=basic_cuts, # Note the only apply the basic_cuts\n",
     "                                  native_filters=['tract == 4849'])\n",
@@ -286,7 +296,7 @@
     "m10map_hsc = depth_map_snr(data_hsc['ra'],data_hsc['dec'],data_hsc['mag_i_cModel'], data_hsc['snr_i_cModel'])\n",
     "\n",
     "# Printing the median depth\n",
-    "print(\"Run1.1p median i-band 10-sigma depth \", np.median(m10map_dc2[m10map_dc2 > 0]))\n",
+    "print(\"Run1.2i median i-band 10-sigma depth \", np.median(m10map_dc2[m10map_dc2 > 0]))\n",
     "print(\"HSC XMM median i-band 10-sigma depth \", np.median(m10map_hsc[m10map_hsc > 0]))"
    ]
   },
@@ -406,16 +416,25 @@
    },
    "outputs": [],
    "source": [
-    "# Create an instance of the data butler for the run 1.1p data repository\n",
-    "repo = REPOS['1.1p']\n",
-    "butler = dafPersist.Butler(repo)\n",
-    "\n",
+    "# Create an instance of the data butler for the run 1.2i data repository\n",
+    "repo = REPOS['1.2i']\n",
+    "butler = dafPersist.Butler(repo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
     "plt.figure(figsize=(15,15));\n",
-    "for i in range(16):\n",
+    "for i, coord in enumerate(zip(data['ra'][:16], data['dec'][:16])):\n",
     "    plt.subplot(4,4,i+1)\n",
     "\n",
     "    # Extract the cutout using the data butler\n",
-    "    cutout_image = cutout_coadd_ra_dec(butler, data['ra'][i], data['dec'][i]);\n",
+    "    cutout_image = cutout_coadd_ra_dec(butler, *coord);\n",
     "    \n",
     "    # Plot the postage stamp on the same scales, with some arcsinh range compression \n",
     "    plt.imshow(np.arcsinh(cutout_image.image.array), vmax=4, cmap='binary');\n",
@@ -448,7 +467,7 @@
     "                              filters=sample_cut,\n",
     "                              native_filters=['tract == 4849'])\n",
     "\n",
-    "data['blendedness'][0:16]"
+    "data['blendedness'][:16]"
    ]
   },
   {
@@ -482,8 +501,8 @@
     "\n",
     "quantities = ['mag_i_cModel', 'snr_i_cModel', 'shape_hsm_regauss_etot', 'ext_shapeHSM_HsmShapeRegauss_resolution']\n",
     "data = catalog.get_quantities(quantities, \n",
-    "                           filters=basic_cuts + properties_cuts, \n",
-    "                           native_filters=['tract == 4849'])"
+    "                              filters=basic_cuts + properties_cuts, \n",
+    "                              native_filters=['tract == 4849'])"
    ]
   },
   {
@@ -496,31 +515,31 @@
    "source": [
     "plt.figure(figsize=(10,10))\n",
     "plt.subplot(221)\n",
-    "plt.hist(data['ext_shapeHSM_HsmShapeRegauss_resolution'], 100, range=[0,1],normed=True, histtype='step', label='New cuts');\n",
+    "plt.hist(data['ext_shapeHSM_HsmShapeRegauss_resolution'], 100, range=[0,1], density=True, histtype='step', label='New cuts');\n",
     "plt.xlabel('i-band resolution')\n",
     "plt.xlim()\n",
     "plt.subplot(222)\n",
-    "plt.hist(data['snr_i_cModel'], 100, range=[0,100],normed=True, histtype='step', label='New cuts')\n",
+    "plt.hist(data['snr_i_cModel'], 100, range=[0,100], density=True, histtype='step', label='New cuts')\n",
     "plt.xlabel('i-band cmodel S/N')\n",
     "plt.subplot(223)\n",
-    "plt.hist(data['mag_i_cModel'], 100, range=[20,25],normed=True, histtype='step', label='New cuts');\n",
+    "plt.hist(data['mag_i_cModel'], 100, range=[20,25], density=True, histtype='step', label='New cuts');\n",
     "plt.xlabel('i-band cmodel mag')\n",
     "plt.subplot(224)\n",
-    "plt.hist(data['shape_hsm_regauss_etot'],100,normed=True, histtype='step', label='New cuts');\n",
+    "plt.hist(data['shape_hsm_regauss_etot'],100, density=True, histtype='step', label='New cuts');\n",
     "plt.xlabel('Ellipticity magniture |e|');\n",
     "plt.subplot(221)\n",
-    "plt.hist(data_basic['ext_shapeHSM_HsmShapeRegauss_resolution'], 100, range=[0,1],normed=True, histtype='step', label='Original cuts');\n",
+    "plt.hist(data_basic['ext_shapeHSM_HsmShapeRegauss_resolution'], 100, range=[0,1], density=True, histtype='step', label='Original cuts');\n",
     "plt.xlabel('i-band resolution')\n",
     "plt.legend(loc='best');\n",
     "plt.xlim()\n",
     "plt.subplot(222)\n",
-    "plt.hist(data_basic['snr_i_cModel'], 100, range=[0,100],normed=True, histtype='step', label='Original cuts')\n",
+    "plt.hist(data_basic['snr_i_cModel'], 100, range=[0,100], density=True, histtype='step', label='Original cuts')\n",
     "plt.xlabel('i-band cmodel S/N')\n",
     "plt.subplot(223)\n",
-    "plt.hist(data_basic['mag_i_cModel'], 100, range=[20,25],normed=True, histtype='step', label='Original cuts');\n",
+    "plt.hist(data_basic['mag_i_cModel'], 100, range=[20,25], density=True, histtype='step', label='Original cuts');\n",
     "plt.xlabel('i-band cmodel mag')\n",
     "plt.subplot(224)\n",
-    "plt.hist(data_basic['shape_hsm_regauss_etot'],100,normed=True, histtype='step', label='Original cuts');\n",
+    "plt.hist(data_basic['shape_hsm_regauss_etot'],100, density=True, histtype='step', label='Original cuts');\n",
     "plt.xlabel('Ellipticity magniture |e|');"
    ]
   },
@@ -537,15 +556,6 @@
    "source": [
     "__If you want, you can check out [Part III: Challenges](object_gcr_3_challenges.ipynb)!__"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR updates the object catalog used in `object_gcr_2_lensing_cuts.ipynb` tutorial from 1.1p to 1.2i.

This PR is still work in progress because there are a few things that I think require the attention of the original notebook authors (@EiffL @fjaviersanchez) and maybe also @wmwv:

When running the notebook as it originally was (i.e., no other changes other than updating 1.1p -> 1.2i), I notice that there are *no* objects passing the `basic_cuts` defined in the beginning of the notebook. I then tried commenting out some cuts and found that `merge_measurement_i` appears to be the cut that causes the issue. 

There are indeed objects who have `merge_measurement_i == True`, but none of these passes other cuts used in the notebook. 

The second part of this notebook (where it explores the `blendedness` cut) also produce quite different results from the 1.1p case. I am not certain if that's due to the removal of `merge_measurement_i` cut, or other issues. 

**Note**: This notebook also suffers from the [issue of mismatching native quantities](https://github.com/LSSTDESC/gcr-catalogs/issues/225). In order for this PR to work, one needs to use https://github.com/LSSTDESC/gcr-catalogs/pull/226. 

@EiffL @fjaviersanchez, please feel free to directly work on this branch `issues/19/object-gcr-tutorial-2-run1.2i`. 

This PR partly addresses #19.