### PR TITLE
update 1.1p to 1.2i in object_gcr_3_challenges

### DIFF
--- a/tutorials/assets/object_gcr_tutorial_part3.py
+++ b/tutorials/assets/object_gcr_tutorial_part3.py
@@ -1,10 +1,10 @@
-# Solution for Challenge 2 of DC2 Coadd Run1.1p GCR tutorial Part III: Guided Challenges
+# Solution for Challenge 2 of DC2 Object Catalog Run1.2i GCR tutorial Part III: Guided Challenges
 import numpy as np
 import matplotlib.pyplot as plt
 import GCRCatalogs
 from GCR import GCRQuery
 
-catalog = GCRCatalogs.load_catalog('dc2_coadd_run1.1p')
+catalog = GCRCatalogs.load_catalog('dc2_object_run1.2i')
 
 filters=[
          GCRQuery('extendedness == 0'),
@@ -34,7 +34,7 @@ quantities = ['ra', 'dec',
 
 # Would be hidden
 data = catalog.get_quantities(quantities, 
-                              native_filters=[(lambda x: x==4850, 'tract')],
+                              native_filters=['tract == 4850'],
                               filters=filters)
 
 plt.figure(figsize=(10,5))
@@ -74,5 +74,3 @@ plt.xlabel('$g_2 - g_2^{PSF}$')
 plt.axvline(0)
 
 plt.savefig('plot2.png')
-
-

--- a/tutorials/object_gcr_3_challenges.ipynb
+++ b/tutorials/object_gcr_3_challenges.ipynb
@@ -7,7 +7,7 @@
     "# DC2 Object Catalog Run1.2i GCR tutorial -- Part III: Guided Challenges\n",
     "\n",
     "Owners: **Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez), Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL)**  \n",
-    "Last Run: **2018-07-25**\n",
+    "Last Run: **2018-11-19** (by @yymao)\n",
     "\n",
     "This notebook is the last in the Run1.2i object catalog with GCR series ([Part I](object_gcr_1_intro.ipynb), [Part II](object_gcr_2_lensing_cuts.ipynb)). Here, we propose some challenges for you as science use cases of the object catalogs. We will provide a solution here but you are encouraged to create your own!\n",
     "\n",

--- a/tutorials/object_gcr_3_challenges.ipynb
+++ b/tutorials/object_gcr_3_challenges.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DC2 Object Catalog Run1.1p GCR tutorial -- Part III: Guided Challenges\n",
+    "# DC2 Object Catalog Run1.2i GCR tutorial -- Part III: Guided Challenges\n",
     "\n",
     "Owners: **Javier Sanchez [@fjaviersanchez](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez), Francois Lanusse [@EiffL](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL)**  \n",
     "Last Run: **2018-07-25**\n",
     "\n",
-    "This notebook is the last in the Run1.1p object catalog with GCR series ([Part I](object_gcr_1_intro.ipynb), [Part II](object_gcr_2_lensing_cuts.ipynb)). Here, we propose some challenges for you as science use cases of the object catalogs. We will provide a solution here but you are encouraged to create your own!\n",
+    "This notebook is the last in the Run1.2i object catalog with GCR series ([Part I](object_gcr_1_intro.ipynb), [Part II](object_gcr_2_lensing_cuts.ipynb)). Here, we propose some challenges for you as science use cases of the object catalogs. We will provide a solution here but you are encouraged to create your own!\n",
     "\n",
     "\n",
     "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC"
@@ -98,7 +98,7 @@
     "import GCRCatalogs\n",
     "from GCR import GCRQuery\n",
     "# Load the object catalog\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')"
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.2i_all_columns')"
    ]
   },
   {
@@ -108,36 +108,30 @@
    "outputs": [],
    "source": [
     "# Let's use almost the same cuts as in the WL sample\n",
-    "tract_number = 4849\n",
-    "cic_cuts_nb = [\n",
-    "    ~GCRQuery((np.isnan, 'mag_i_cModel')), # (from this and below) remove nan entries\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_resolution')),\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_e1')),\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_e2')),\n",
+    "\n",
+    "cic_cuts_base = [\n",
+    "    GCRQuery((np.isfinite, 'mag_i_cModel')), # (from this and below) remove nan entries\n",
+    "    GCRQuery((np.isfinite, 'ext_shapeHSM_HsmShapeRegauss_resolution')),\n",
+    "    GCRQuery((np.isfinite, 'ext_shapeHSM_HsmShapeRegauss_e1')),\n",
+    "    GCRQuery((np.isfinite, 'ext_shapeHSM_HsmShapeRegauss_e2')),\n",
     "    GCRQuery('good'), \n",
     "    GCRQuery('snr_i_cModel >= 10'), # (from this and below) cut on object properties\n",
     "    GCRQuery('ext_shapeHSM_HsmShapeRegauss_sigma <= 0.4'),\n",
-    "    GCRQuery('blendedness < 10**(-0.375)'),\n",
     "]\n",
     "\n",
-    "cic_cuts_b = [\n",
-    "    ~GCRQuery((np.isnan, 'mag_i_cModel')), # (from this and below) remove nan entries\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_resolution')),\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_e1')),\n",
-    "    ~GCRQuery((np.isnan, 'ext_shapeHSM_HsmShapeRegauss_e2')),\n",
-    "    GCRQuery('good'), \n",
-    "    GCRQuery('snr_i_cModel >= 10'), # (from this and below) cut on object properties\n",
-    "    GCRQuery('ext_shapeHSM_HsmShapeRegauss_sigma <= 0.4'),\n",
-    "    GCRQuery('blendedness > 10**(-0.375)'),\n",
-    "]\n",
+    "is_blended = GCRQuery('blendedness >= 10**(-0.375)')\n",
+    "\n",
+    "cic_cuts_nb = cic_cuts_base + [~is_blended]\n",
+    "cic_cuts_b = cic_cuts_base + [is_blended]\n",
     "\n",
     "quantities = ['ra','dec']\n",
+    "\n",
     "d_nb = catalog.get_quantities(quantities, \n",
-    "                           filters=cic_cuts_nb, \n",
-    "                           native_filters=[(lambda x: x==tract_number, 'tract')])\n",
+    "                              filters=cic_cuts_nb, \n",
+    "                              native_filters=['tract == 4849'])\n",
     "d_b = catalog.get_quantities(quantities, \n",
-    "                           filters=cic_cuts_b, \n",
-    "                           native_filters=[(lambda x: x==tract_number, 'tract')])"
+    "                             filters=cic_cuts_b, \n",
+    "                             native_filters=['tract == 4849'])"
    ]
   },
   {
@@ -148,7 +142,7 @@
    "source": [
     "m10map = hp.read_map('assets/DC2_10sigma_depth.fits.gz') # This is the 10 sigma map \n",
     "mask = np.zeros_like(m10map)\n",
-    "mask[m10map>23.0] = 1.0"
+    "mask[m10map > 23.0] = 1.0"
    ]
   },
   {
@@ -157,7 +151,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hp.gnomview(mask,rot=(d_nb['ra'].mean(), d_nb['dec'].mean()), title='Run 1.1 Depth', reso=0.5,unit='10-$\\sigma$ i-band depth')"
+    "hp.gnomview(mask, rot=(d_nb['ra'].mean(), d_nb['dec'].mean()), title='Run 1.2i Depth', reso=0.5, unit='10-$\\sigma$ i-band depth')"
    ]
   },
   {
@@ -167,7 +161,7 @@
    "outputs": [],
    "source": [
     "sigma_b, sigma_err_b, skw_b, skw_err_b, kurtosis_b, kurtosis_err_b, pixel_scale = cic_analysis(d_b, mask, nboot=100)\n",
-    "sigma_nb, sigma_err_nb, skw_nb, skw_err_nb, kurtosis_nb, kurtosis_err_nb, _  = cic_analysis(d_nb, mask, nboot=100)"
+    "sigma_nb, sigma_err_nb, skw_nb, skw_err_nb, kurtosis_nb, kurtosis_err_nb, _ = cic_analysis(d_nb, mask, nboot=100)"
    ]
   },
   {
@@ -176,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f, ax = plt.subplots(1,3,figsize=(16,4))\n",
+    "f, ax = plt.subplots(1, 3, figsize=(13,4))\n",
     "ax[0].errorbar(pixel_scale, sigma_b, sigma_err_b, fmt='o', linestyle='none', label='High blendedness')\n",
     "ax[0].errorbar(pixel_scale, sigma_nb, sigma_err_nb, fmt='x', linestyle='none', label='Low blendedness')\n",
     "ax[0].legend()\n",
@@ -191,7 +185,8 @@
     "ax[2].errorbar(pixel_scale, kurtosis_nb, kurtosis_err_nb, fmt='x', linestyle='none', label='Low blendedness')\n",
     "ax[2].legend()\n",
     "ax[2].set_xlabel('Pixel scale [deg]')\n",
-    "ax[2].set_ylabel(r'$S_{4}$')"
+    "ax[2].set_ylabel(r'$S_{4}$')\n",
+    "f.tight_layout()"
    ]
   },
   {
@@ -207,7 +202,7 @@
    "source": [
     "## Challenge 2: Check if PSF residuals are within requirements\n",
     "\n",
-    "In this section, we will try to apply all the tools we have covered during this tutorial to test the quality of the DM stack PSF model on run 1.1p.\n",
+    "In this section, we will try to apply all the tools we have covered during this tutorial to test the quality of the DM stack PSF model on run 1.2i.\n",
     "\n",
     "The challenge will be to select a clean sample of stars, compute their size and ellipticity using second moments, and compare those to the PSF model predicted by the DM stack. We will test the one point and two point fuctions of these residuals to make diagnostic plots that would directly go into a weak lensing shape catalog paper.\n",
     "\n",
@@ -238,9 +233,9 @@
     "import GCRCatalogs\n",
     "from GCR import GCRQuery\n",
     "\n",
-    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.1p')\n",
+    "catalog = GCRCatalogs.load_catalog('dc2_object_run1.2i')\n",
     "\n",
-    "filters=[\n",
+    "filters = [\n",
     "    # Add the required filters\n",
     "    # ...\n",
     "]"
@@ -431,7 +426,7 @@
     "If you have reached that point, well done! \n",
     "Feel free to explore the other functionalities of Stile, including Histogram plots, Whiskers plots, and some fancy summary statistics (MAD, skewness, and kurtosis). Find Hironao, Rachel, or ping Melanie if you are interested in knowing more.\n",
     "\n",
-    "And if you have reached this point out of desperation and are looking for answers, [here](assets/gcr_coadd_tutorial_part3.py) they are :-)"
+    "And if you have reached this point out of desperation and are looking for answers, [here](assets/object_gcr_tutorial_part3.py) they are :-)"
    ]
   }
  ],
@@ -451,7 +446,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.6.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Just like the other recent PRs, this PR updates the object catalog used in `object_gcr_3_challenges.ipynb` tutorial from 1.1p to 1.2i.

Changes are straightforward, but I did update the cell that defines `cic_cuts_nb` and `cic_cuts_b` to reduce the amount of repeated code. 

This PR partly addresses #19.
