### PR TITLE
U/heather999/remove path update hack

### DIFF
--- a/tutorials/matching_stack.ipynb
+++ b/tutorials/matching_stack.ipynb
@@ -42,10 +42,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# to allow local import when using desc-stack kernel\n",
-    "import sys\n",
-    "sys.path.insert(0, '')\n",
-    "\n",
     "from utils.fieldRotator import FieldRotator"
    ]
   },

--- a/tutorials/object_gcr_2_lensing_cuts.ipynb
+++ b/tutorials/object_gcr_2_lensing_cuts.ipynb
@@ -194,11 +194,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# hack to make local import work with desc-stack kernel\n",
-    "import sys\n",
-    "if '' not in sys.path:\n",
-    "    sys.path.insert(0, '')\n",
-    "\n",
     "# Import an efficient alternative to binned_statistic_2d, defined in utils/cic.py\n",
     "from utils.cic import binned_statistic\n",
     "    \n",


### PR DESCRIPTION
Due to an update to the desc-stack kernel, it is no longer necessary to insert the current working directory into the path.  I've tried this branch, and these two specific notebook in jupyter-dev with the current desc-stack, and loading the utils works just fine.