### PR TITLE
Add photo-z (for object catalog) tutorial

### DIFF
--- a/tutorials/README.rst
+++ b/tutorials/README.rst
@@ -73,7 +73,7 @@ Notes for Tutorial Users
        .. image:: https://github.com/LSSTDESC/DC2-analysis/blob/rendered/tutorials/log/object_gcr_4_photoz.svg
           :target: https://github.com/LSSTDESC/DC2-analysis/blob/rendered/tutorials/log/object_gcr_4_photoz.log
 
-     - `Yao-Yuan Mao <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao>`_
+     - `Yao-Yuan Mao <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao>`_, `Sam Schmidt <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@sschmidt23>`_
 
 
    * - Object catalog with Spark

--- a/tutorials/README.rst
+++ b/tutorials/README.rst
@@ -66,6 +66,16 @@ Notes for Tutorial Users
      - `Francois Lanusse <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@EiffL>`_, `Javier Sanchez <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@fjaviersanchez>`_
 
 
+   * - Object catalog GCR Tutorial Part IV: Photo-z information
+     - Use the GCR to access the Photo-z information that are provided as an "add-on" to the object catalog
+     - `ipynb <object_gcr_4_photoz.ipynb>`_, `rendered <https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/object_gcr_4_photoz.nbconvert.ipynb>`_
+
+       .. image:: https://github.com/LSSTDESC/DC2-analysis/blob/rendered/tutorials/log/object_gcr_4_photoz.svg
+          :target: https://github.com/LSSTDESC/DC2-analysis/blob/rendered/tutorials/log/object_gcr_4_photoz.log
+
+     - `Yao-Yuan Mao <https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao>`_
+
+
    * - Object catalog with Spark
      - Introduction of using Spark to access the object catalogs
      - `ipynb <object_spark_1_intro.ipynb>`_, `rendered <https://nbviewer.jupyter.org/github/LSSTDESC/DC2-analysis/blob/rendered/tutorials/object_spark_1_intro.nbconvert.ipynb>`_

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -28,6 +28,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import sys\n",
+    "sys.path.insert(0, '../../gcr-catalogs/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
@@ -49,9 +59,9 @@
    "source": [
     "## Load the catalog\n",
     "\n",
-    "Loading the object catalog with photo-z add-on. The catalog name is `dc2_object_run1.2i_with_pz`. \n",
+    "Loading the object catalog with photo-z add-on. The catalog name is `dc2_object_run1.2i_with_photoz`. \n",
     "\n",
-    "**Note**: if you need more quantities (including those not in DPDD), then use `dc2_object_run1.2i_all_columns_with_pz` instead.\n",
+    "**Note**: if you need more quantities (including those not in DPDD), then use `dc2_object_run1.2i_all_columns_with_photoz` instead.\n",
     "\n",
     "It takes a few seconds for the catalog instance to initiate."
    ]
@@ -62,7 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = GCRCatalogs.load_catalog('dc2_object_run1.2i_with_pz')"
+    "cat = GCRCatalogs.load_catalog('dc2_object_run1.2i_with_photoz')"
    ]
   },
   {
@@ -71,13 +81,12 @@
    "source": [
     "## Photo-z access methods\n",
     "\n",
-    "The photo-z infomation can be accessed in three ways:\n",
+    "The photo-z infomation can be accessed in two ways:\n",
     "\n",
-    "1. As a single column `pz_z_peak` that has the peak value, and\n",
-    "2. As 101 separate columns (`pz_z0_005`, `pz_z0_015`, ..., `pz_z1_105`), each has the PDF value at a certain z. \n",
-    "3. As a single multi-dimension coulmn `pz_pdf_full` (i.e., when accessing this column, you get a 2D array instead of a 1D one). \n",
+    "1. As a single column `photoz_mode` that has the mode value (z_peak), and\n",
+    "2. As a single multi-dimension coulmn `photoz_pdf` (i.e., when accessing this column, you get a 2D array instead of a 1D one). \n",
     "\n",
-    "We will demostrate each of the access methods. You can notice that all the photo-z columns have a prefix of `pz_`. \n",
+    "We will demostrate both access method in detail. You can notice that all the photo-z columns have a prefix of `photoz_`. \n",
     "\n",
     "Let's first make sure that these columns are indeed available. "
    ]
@@ -88,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sorted(q for q in cat.list_all_quantities() if q.startswith('pz_'))"
+    "sorted(q for q in cat.list_all_quantities() if q.startswith('photoz_'))"
    ]
   },
   {
@@ -105,15 +114,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = cat.get_quantities(['pz_z_peak', 'pz_pdf_z0_905'], \n",
-    "                          filters=['pz_z_peak < 0.2', 'mag_i < 26'], \n",
+    "data = cat.get_quantities(['photoz_mode'], \n",
+    "                          filters=['photoz_mode < 0.2', 'mag_i < 26'], \n",
     "                          native_filters=['tract==4850'])\n",
     "\n",
     "# check if the filters work\n",
-    "print((data['pz_z_peak'] < 0.2).all())\n",
-    "\n",
-    "# check if most objects whose z_peak < 0.2 also have p(z=0.905) = 0. \n",
-    "print(len(data['pz_pdf_z0_905']), np.count_nonzero(data['pz_pdf_z0_905'] == 0))"
+    "print((data['photoz_mode'] < 0.2).all())"
    ]
   },
   {
@@ -131,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = next(cat.get_quantities(['pz_pdf_full'], return_iterator=True))"
+    "data = next(cat.get_quantities(['photoz_pdf'], return_iterator=True))"
    ]
   },
   {
@@ -147,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data['pz_pdf_full'].shape"
+    "data['photoz_pdf'].shape"
    ]
   },
   {
@@ -163,8 +169,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for pdf in data['pz_pdf_full'][:10]:\n",
-    "    plt.plot(cat.pz_pdf_bin_centers, pdf);\n",
+    "for pdf in data['photoz_pdf'][:10]:\n",
+    "    plt.plot(cat.photoz_pdf_bin_centers, pdf);\n",
     "\n",
     "plt.xlabel('$z$');\n",
     "plt.ylabel('$p(z)$');"
@@ -211,7 +217,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = cat.get_quantities(['pz_z_peak', 'mag_g_cModel', 'mag_r_cModel', 'mag_i_cModel'], filters=cuts, native_filters=['tract==4850'])"
+    "data = cat.get_quantities(['photoz_mode', 'mag_g_cModel', 'mag_r_cModel', 'mag_i_cModel'], filters=cuts, native_filters=['tract==4850'])"
    ]
   },
   {
@@ -220,7 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist(data['pz_z_peak'], 50);"
+    "plt.hist(data['photoz_mode'], 50);"
    ]
   },
   {
@@ -231,7 +237,7 @@
    "source": [
     "plt.scatter(data['mag_g_cModel'] - data['mag_r_cModel'],\n",
     "            data['mag_r_cModel'] - data['mag_i_cModel'],\n",
-    "            c=data['pz_z_peak'], s=4, vmin=0, vmax=1);\n",
+    "            c=data['photoz_mode'], s=4, vmin=0, vmax=1);\n",
     "\n",
     "plt.xlim(-1, 3);\n",
     "plt.ylim(-0.5, 2);\n",

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -6,8 +6,10 @@
    "source": [
     "# DC2 Object Catalog Run1.2i GCR tutorial -- Part IV: accessing photo-z\n",
     "\n",
-    "Owners: **Yao-Yuan Mao [@yymao](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao)**  \n",
-    "Last Verifed to Run: **2019-02-22** (by @yymao)\n",
+    "Owners: **Yao-Yuan Mao [@yymao](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao)**, \n",
+    "        **Sam Schmidt [@sschmidt23](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@sschmidt23)**\n",
+    "\n",
+    "Last Verifed to Run: **2019-02-25** (by @yymao)\n",
     "\n",
     "This notebook will show you how to access the \"add-on\" columns that provide the photometric redshift (photo-z) information for the DC2 Object Catalog (Run 1.2i). \n",
     "\n",
@@ -172,28 +174,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(11,14))\n",
-    "n_plotted = 0\n",
-    "for pdf, z_peak in zip(data['photoz_pdf'], data['photoz_mode']):\n",
-    "    ax = plt.subplot(5,2,n_plotted+1)\n",
-    "    l = plt.plot(cat.photoz_pdf_bin_centers, pdf);\n",
-    "    plt.axvline(z_peak, color=l[0].get_color(), ls=':', lw=1);\n",
-    "    #print(z_peak)\n",
-    "    n_plotted += 1\n",
-    "    plt.xlabel('$z$');\n",
-    "    plt.ylabel('$p(z)$');\n",
-    "    if n_plotted >= 10:\n",
-    "        break"
+    "fig, ax = plt.subplots(5, 2, figsize=(11,14))\n",
+    "for pdf, z_peak, ax_this in zip(data['photoz_pdf'], data['photoz_mode'], ax.flat):\n",
+    "    l = ax_this.plot(cat.photoz_pdf_bin_centers, pdf);\n",
+    "    ax_this.axvline(z_peak, color=l[0].get_color(), ls=':', lw=1);\n",
+    "    ax_this.set_xlabel('$z$');\n",
+    "    ax_this.set_ylabel('$p(z)$');"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hmmm, we have printed 10 PDFs but there are only 8 curves and 7 vertical dashed lines. What's going on? \n",
-    "Uncomment the print statement in the above cell to inspect!\n",
-    "\n",
-    "Also, note that these PDFs only go to $z=1$. This is because the photo-z catalog presented here is just a test catalog, and Run 1.2x is using protoDC2, which only contains galaxies up to $z=1$. "
+    "Note that these PDFs only go to $z=1$. This is because the photo-z catalog presented here is just a test catalog, and Run 1.2x is using protoDC2, which only contains galaxies up to $z=1$. "
    ]
   },
   {
@@ -257,10 +250,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist(data['photoz_mode'], 100,label=\"photoz_mode\")\n",
-    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf,label=\"summed p(z)\")\n",
-    "plt.xlabel(\"redshift\")\n",
-    "plt.legend(loc='upper left')"
+    "plt.hist(data['photoz_mode'], 100, label=\"photo-z mode\");\n",
+    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf,label=\"summed $p(z)$\");\n",
+    "plt.xlabel(\"redshift\");\n",
+    "plt.legend(loc='upper left');"
    ]
   },
   {
@@ -302,7 +295,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bin_cut = np.logical_and(data['photoz_mode']>0.6, data['photoz_mode']<0.8)\n",
+    "bin_cut = GCRQuery('photoz_mode > 0.6', 'photoz_mode < 0.8').mask(data)\n",
     "sumpdf_bin = np.sum(data['photoz_pdf'][bin_cut],axis=0)"
    ]
   },
@@ -312,10 +305,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist(data['photoz_mode'][bin_cut], 100,label=\"photoz_mode 0.6<mode<0.8\")\n",
-    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf_bin,label=\"summed p(z) 0.6<mode<0.8\")\n",
-    "plt.xlabel(\"redshift\")\n",
-    "plt.legend(loc='upper left')"
+    "plt.hist(data['photoz_mode'][bin_cut], 100, label=r'photo-z mode, $0.6 < z_{\\rm mode} < 0.8$');\n",
+    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf_bin, label=r'summed $p(z)$, $0.6 < z_{\\rm mode} < 0.8$');\n",
+    "plt.xlabel(\"redshift\");\n",
+    "plt.legend(loc='upper left');"
    ]
   },
   {
@@ -341,13 +334,6 @@
    "source": [
     "We see that that distributions of mode values versus stacked p(z) differ slightly, particularly in extended \"wings\" that extend beyond the bin boundaries.  We also see that the range of colors for this tomographic bin is restricted compared to the overall distribution.  Users may want to modify bin definitions by looking at color distributions to avoid common degeneracies."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -74,12 +74,12 @@
     "The photo-z infomation can be accessed in two ways:\n",
     "\n",
     "1. As a single column `photoz_mode` that has the mode value (z_peak), and\n",
-    "2. As a single multi-dimension column `photoz_pdf` \n",
+    "2. As a single multi-dimensional column `photoz_pdf` \n",
     "   (i.e., when accessing this column, you get a 2D array (objects x PDF values) instead of a 1D array). \n",
     "   Note that the column contains only the PDF values, not the bin center values. \n",
     "   The PDF bin centers are stored in a catalog attribute named `photoz_pdf_bin_centers`. \n",
     "\n",
-    "We will demostrate both access method in detail. You can notice that all the photo-z columns have a prefix of `photoz_`. \n",
+    "We will demonstrate both access methods in detail. You can notice that all the photo-z columns have a prefix of `photoz_`. \n",
     "\n",
     "Let's first make sure that these columns are indeed available. "
    ]
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let try access the photo-z data! Everything you already about the GCR access of object catalogs will still apply. \n",
+    "Let's now try access the photo-z data! Everything you already about the GCR access of object catalogs will still apply. \n",
     "Including the use of `filters` and `native_filters` (`native_filters` is used for selecting tracts mostly). "
    ]
   },
@@ -119,7 +119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, if you want to make a plot of the PDF, it might be easier to access the `photoz_pdf` column. Note that it is a multi-dimension column, so use with care!\n",
+    "Now, if you want to make a plot of the PDF, it might be easier to access the `photoz_pdf` column. Note that it is a multi-dimensional column, so use with care!\n",
     "\n",
     "As an example, let's just load one patch (using the `return_iterator` feature) of the full PDFs and also peak values at the same time:"
    ]
@@ -137,7 +137,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 72 objects in this patch, and there are 101 bins in the photo-z PDF, so this 2D array has a shape of (72, 101). Note how the 2D array is orientied."
+    "There are 72 objects in this patch, and there are 101 bins in the photo-z PDF, so this 2D array has a shape of (72, 101). Note how the 2D array is oriented."
    ]
   },
   {
@@ -166,12 +166,23 @@
     "for pdf, z_peak in zip(data['photoz_pdf'], data['photoz_mode']):\n",
     "    l = plt.plot(cat.photoz_pdf_bin_centers, pdf);\n",
     "    plt.axvline(z_peak, color=l[0].get_color(), ls=':', lw=1);\n",
+    "    #print(z_peak)\n",
     "    n_plotted += 1\n",
     "    if n_plotted >= 10:\n",
     "        break\n",
     "\n",
     "plt.xlabel('$z$');\n",
     "plt.ylabel('$p(z)$');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hmmm, we have printed 10 PDFs but there are only 8 curves and 7 vertical dashed lines. What's going on? \n",
+    "Uncomment the print statement in the above cell to inspect!\n",
+    "\n",
+    "Also, note that these PDFs only go to $z=1$. This is because the photo-z catalog presented here is just a test catalog, and Run 1.2x is using protoDC2, which only contains galaxies up to $z=1$ too. "
    ]
   },
   {
@@ -245,13 +256,6 @@
     "\n",
     "# Food for thought: Look at how the photo-z values are distributed in this color-color space. Is this behavior expected?"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -223,7 +223,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's make some plots!  Let's compare the histogram of photoz_mode values to the sum of the individual PDF values, the \"stacked\" PDF being a common way of estimating redshift distributions:"
+    "Now let's make some plots!  Let's compare the histogram of photoz_mode values to the sum of the individual PDF values, the \"stacked\" PDF being a common (but not statistically correct) way of estimating redshift distributions:"
    ]
   },
   {

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -150,10 +150,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print (data['photoz_mode'][:10])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's plot 10 PDFs. To get an array of bin center values, you can access the `pz_pdf_bin_centers` attribute. "
+    "Now, let's plot 10 PDFs. The PDFs were evaluated on a set grid of redshift values.  For run1.2 this grid only extended to z=1.0, as the protoDC2 catalog only covered this range, for future releases the photo-z range will expand to higher redshift. <br>\n",
+    "To get the array of bin center values, you can access the `pz_pdf_bin_centers` attribute. "
    ]
   },
   {
@@ -162,17 +172,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plt.figure(figsize=(11,14))\n",
     "n_plotted = 0\n",
     "for pdf, z_peak in zip(data['photoz_pdf'], data['photoz_mode']):\n",
+    "    ax = plt.subplot(5,2,n_plotted+1)\n",
     "    l = plt.plot(cat.photoz_pdf_bin_centers, pdf);\n",
     "    plt.axvline(z_peak, color=l[0].get_color(), ls=':', lw=1);\n",
     "    #print(z_peak)\n",
     "    n_plotted += 1\n",
+    "    plt.xlabel('$z$');\n",
+    "    plt.ylabel('$p(z)$');\n",
     "    if n_plotted >= 10:\n",
-    "        break\n",
-    "\n",
-    "plt.xlabel('$z$');\n",
-    "plt.ylabel('$p(z)$');"
+    "        break"
    ]
   },
   {
@@ -182,7 +193,7 @@
     "Hmmm, we have printed 10 PDFs but there are only 8 curves and 7 vertical dashed lines. What's going on? \n",
     "Uncomment the print statement in the above cell to inspect!\n",
     "\n",
-    "Also, note that these PDFs only go to $z=1$. This is because the photo-z catalog presented here is just a test catalog, and Run 1.2x is using protoDC2, which only contains galaxies up to $z=1$ too. "
+    "Also, note that these PDFs only go to $z=1$. This is because the photo-z catalog presented here is just a test catalog, and Run 1.2x is using protoDC2, which only contains galaxies up to $z=1$. "
    ]
   },
   {
@@ -207,9 +218,11 @@
     "    GCRQuery((np.isfinite, 'mag_i')), # Select objects that have i-band magnitudes\n",
     "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
     "                       # and was not skipped by the deblender\n",
-    "    GCRQuery('snr_i_cModel > 10'),    # SNR > 10\n",
+    "    GCRQuery('snr_i_cModel > 20'),    # SNR > 10\n",
+    "    GCRQuery('snr_r_cModel > 20'),\n",
+    "    GCRQuery('snr_g_cModel > 20'),\n",
     "    GCRQuery('mag_i_cModel < 22'),  # cModel imag brighter than 22\n",
-    "    GCRQuery('mag_i_cModel > 20'),  # cModel imag fainter than 20 (exclude super bright objects)\n",
+    "    GCRQuery('mag_i_cModel > 20')  # cModel imag fainter than 20 (exclude super bright objects)\n",
     "]"
    ]
   },
@@ -217,7 +230,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's make some plots!"
+    "Now let's make some plots!  Let's compare the histogram of photoz_mode values to the sum of the individual PDF values, the \"stacked\" PDF being a common way of estimating redshift distributions:"
    ]
   },
   {
@@ -226,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = cat.get_quantities(['photoz_mode', 'mag_g_cModel', 'mag_r_cModel', 'mag_i_cModel'], filters=cuts, native_filters=['tract==4850'])"
+    "data = cat.get_quantities(['photoz_mode', 'mag_g_cModel', 'mag_r_cModel', 'mag_i_cModel','photoz_pdf'], filters=cuts, native_filters=['tract==4850'])"
    ]
   },
   {
@@ -235,7 +248,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist(data['photoz_mode'], 50);"
+    "sumpdf = np.sum(data['photoz_pdf'],axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(data['photoz_mode'], 100,label=\"photoz_mode\")\n",
+    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf,label=\"summed p(z)\")\n",
+    "plt.xlabel(\"redshift\")\n",
+    "plt.legend(loc='upper left')"
    ]
   },
   {
@@ -256,6 +281,73 @@
     "\n",
     "# Food for thought: Look at how the photo-z values are distributed in this color-color space. Is this behavior expected?"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see a strong correlation between redshift and position in color space, however the colors are determined by both the SED shape and redshift, so we also see degenerate areas, particularly at the blue end near color = 0.0 where low and high redshift solutions are close in color space."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's also examine a tomographic slice selected in terms of photoz_mode:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bin_cut = np.logical_and(data['photoz_mode']>0.6, data['photoz_mode']<0.8)\n",
+    "sumpdf_bin = np.sum(data['photoz_pdf'][bin_cut],axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(data['photoz_mode'][bin_cut], 100,label=\"photoz_mode 0.6<mode<0.8\")\n",
+    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf_bin,label=\"summed p(z) 0.6<mode<0.8\")\n",
+    "plt.xlabel(\"redshift\")\n",
+    "plt.legend(loc='upper left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(data['mag_g_cModel'][bin_cut] - data['mag_r_cModel'][bin_cut],\n",
+    "            data['mag_r_cModel'][bin_cut] - data['mag_i_cModel'][bin_cut],\n",
+    "            c=data['photoz_mode'][bin_cut], s=4, vmin=0, vmax=1);\n",
+    "\n",
+    "plt.xlim(-1, 3);\n",
+    "plt.ylim(-0.5, 2);\n",
+    "plt.xlabel('$g-r$');\n",
+    "plt.ylabel('$r-i$');\n",
+    "plt.colorbar(label='$z$');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that that distributions of mode values versus stacked p(z) differ slightly, particularly in extended \"wings\" that extend beyond the bin boundaries.  We also see that the range of colors for this tomographic bin is restricted compared to the overall distribution.  Users may want to modify bin definitions by looking at color distributions to avoid common degeneracies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DC2 Object Catalog Run1.2i GCR tutorial -- Part IV: accessing photo-z\n",
+    "\n",
+    "Owners: **Yao-Yuan Mao [@yymao](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao)**  \n",
+    "Last Verifed to Run: **2019-02-22** (by @yymao)\n",
+    "\n",
+    "This notebook will show you how to access the \"add-on\" columns that provide the photometric redshift (photo-z) information for the DC2 Object Catalog (Run 1.2i). \n",
+    "\n",
+    "__Learning objectives__: After going through this notebook, you should be able to:\n",
+    "  1. Load and efficiently access a DC2 object catalog (+ photo-z) with the GCR\n",
+    "  2. Understand how the photo-z data are stored / represented\n",
+    "  3. Look at an example of galaxy photo-z distributions\n",
+    "  \n",
+    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC\n",
+    "\n",
+    "__Other notes__: \n",
+    "If you restart your kernel, or if it automatically restarts for some reason, all imports and variables will become undefined so, you will have to re-run everything."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import GCRCatalogs\n",
+    "from GCR import GCRQuery"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the catalog\n",
+    "\n",
+    "Loading the object catalog with photo-z add-on. The catalog name is `dc2_object_run1.2i_with_pz`. \n",
+    "\n",
+    "**Note**: if you need more quantities (including those not in DPDD), then use `dc2_object_run1.2i_all_columns_with_pz` instead.\n",
+    "\n",
+    "It takes a few seconds for the catalog instance to initiate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat = GCRCatalogs.load_catalog('dc2_object_run1.2i_with_pz')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Photo-z access methods\n",
+    "\n",
+    "The photo-z infomation can be accessed in three ways:\n",
+    "\n",
+    "1. As a single column `pz_z_peak` that has the peak value, and\n",
+    "2. As 101 separate columns (`pz_z0_005`, `pz_z0_015`, ..., `pz_z1_105`), each has the PDF value at a certain z. \n",
+    "3. As a single multi-dimension coulmn `pz_pdf_full` (i.e., when accessing this column, you get a 2D array instead of a 1D one). \n",
+    "\n",
+    "We will demostrate each of the access methods. You can notice that all the photo-z columns have a prefix of `pz_`. \n",
+    "\n",
+    "Let's first make sure that these columns are indeed available. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sorted(q for q in cat.list_all_quantities() if q.startswith('pz_'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let try access the photo-z data! Everything you already about the GCR access of object catalogs will still apply. \n",
+    "Including the use of `filters` and `native_filters` (`native_filters` is used for selecting tracts mostly). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = cat.get_quantities(['pz_z_peak', 'pz_pdf_z0_905'], \n",
+    "                          filters=['pz_z_peak < 0.2', 'mag_i < 26'], \n",
+    "                          native_filters=['tract==4850'])\n",
+    "\n",
+    "# check if the filters work\n",
+    "print((data['pz_z_peak'] < 0.2).all())\n",
+    "\n",
+    "# check if most objects whose z_peak < 0.2 also have p(z=0.905) = 0. \n",
+    "print(len(data['pz_pdf_z0_905']), np.count_nonzero(data['pz_pdf_z0_905'] == 0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, if you want to make a plot of the PDF, it might be easier to access the `pz_pdf_full` column. Note that it is a multi-dimension column, so use with care!\n",
+    "\n",
+    "As an example, let's just load one patch (using the `return_iterator` feature) of the full PDFs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = next(cat.get_quantities(['pz_pdf_full'], return_iterator=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are 72 objects in this patch, and there are 101 bins in the photo-z PDF, so this 2D array has a shape of (72, 101). Note how the 2D array is orientied."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data['pz_pdf_full'].shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, let's plot 10 PDFs. To get an array of bin center values, you can access the `pz_pdf_bin_centers` attribute. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for pdf in data['pz_pdf_full'][:10]:\n",
+    "    plt.plot(cat.pz_pdf_bin_centers, pdf);\n",
+    "\n",
+    "plt.xlabel('$z$');\n",
+    "plt.ylabel('$p(z)$');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example\n",
+    "\n",
+    "Now that we have learned all the access methods, let's try to work out an example!\n",
+    "\n",
+    "First of all, let's define a set of reasonable cuts to give us galaxies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cuts = [\n",
+    "    GCRQuery('extendedness > 0'),     # Extended objects\n",
+    "    GCRQuery((np.isfinite, 'mag_i')), # Select objects that have i-band magnitudes\n",
+    "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
+    "                       # and was not skipped by the deblender\n",
+    "    GCRQuery('snr_i_cModel > 10'),    # SNR > 10\n",
+    "    GCRQuery('mag_i_cModel < 22'),  # cModel imag brighter than 22\n",
+    "    GCRQuery('mag_i_cModel > 20'),  # cModel imag fainter than 20 (exclude super bright objects)\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's make some plots!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = cat.get_quantities(['pz_z_peak', 'mag_g_cModel', 'mag_r_cModel', 'mag_i_cModel'], filters=cuts, native_filters=['tract==4850'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(data['pz_z_peak'], 50);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.scatter(data['mag_g_cModel'] - data['mag_r_cModel'],\n",
+    "            data['mag_r_cModel'] - data['mag_i_cModel'],\n",
+    "            c=data['pz_z_peak'], s=4, vmin=0, vmax=1);\n",
+    "\n",
+    "plt.xlim(-1, 3);\n",
+    "plt.ylim(-0.5, 2);\n",
+    "plt.xlabel('$g-r$');\n",
+    "plt.ylabel('$r-i$');\n",
+    "plt.colorbar(label='$z$');"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "desc-python",
+   "language": "python",
+   "name": "desc-python"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -28,16 +28,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(0, '../../gcr-catalogs/')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
@@ -84,7 +74,10 @@
     "The photo-z infomation can be accessed in two ways:\n",
     "\n",
     "1. As a single column `photoz_mode` that has the mode value (z_peak), and\n",
-    "2. As a single multi-dimension coulmn `photoz_pdf` (i.e., when accessing this column, you get a 2D array instead of a 1D one). \n",
+    "2. As a single multi-dimension column `photoz_pdf` \n",
+    "   (i.e., when accessing this column, you get a 2D array (objects x PDF values) instead of a 1D array). \n",
+    "   Note that the column contains only the PDF values, not the bin center values. \n",
+    "   The PDF bin centers are stored in a catalog attribute named `photoz_pdf_bin_centers`. \n",
     "\n",
     "We will demostrate both access method in detail. You can notice that all the photo-z columns have a prefix of `photoz_`. \n",
     "\n",

--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -119,9 +119,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, if you want to make a plot of the PDF, it might be easier to access the `pz_pdf_full` column. Note that it is a multi-dimension column, so use with care!\n",
+    "Now, if you want to make a plot of the PDF, it might be easier to access the `photoz_pdf` column. Note that it is a multi-dimension column, so use with care!\n",
     "\n",
-    "As an example, let's just load one patch (using the `return_iterator` feature) of the full PDFs:"
+    "As an example, let's just load one patch (using the `return_iterator` feature) of the full PDFs and also peak values at the same time:"
    ]
   },
   {
@@ -130,7 +130,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = next(cat.get_quantities(['photoz_pdf'], return_iterator=True))"
+    "data = next(cat.get_quantities(['photoz_pdf', 'photoz_mode'], return_iterator=True))"
    ]
   },
   {
@@ -162,8 +162,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for pdf in data['photoz_pdf'][:10]:\n",
-    "    plt.plot(cat.photoz_pdf_bin_centers, pdf);\n",
+    "n_plotted = 0\n",
+    "for pdf, z_peak in zip(data['photoz_pdf'], data['photoz_mode']):\n",
+    "    l = plt.plot(cat.photoz_pdf_bin_centers, pdf);\n",
+    "    plt.axvline(z_peak, color=l[0].get_color(), ls=':', lw=1);\n",
+    "    n_plotted += 1\n",
+    "    if n_plotted >= 10:\n",
+    "        break\n",
     "\n",
     "plt.xlabel('$z$');\n",
     "plt.ylabel('$p(z)$');"
@@ -236,8 +241,17 @@
     "plt.ylim(-0.5, 2);\n",
     "plt.xlabel('$g-r$');\n",
     "plt.ylabel('$r-i$');\n",
-    "plt.colorbar(label='$z$');"
+    "plt.colorbar(label='$z$');\n",
+    "\n",
+    "# Food for thought: Look at how the photo-z values are distributed in this color-color space. Is this behavior expected?"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Here's a simple tutorial for the newly added photo-z "add-on" to the object catalog (1.2i). The photo-z catalog was provided by @sschmidt23 and the reader is currently in PR https://github.com/LSSTDESC/gcr-catalogs/pull/266. 

To run this notebook, you will need to use GCRCatalog at https://github.com/LSSTDESC/gcr-catalogs/pull/266. 

You can preview the rendered (but not run) notebook [here](https://github.com/LSSTDESC/DC2-analysis/blob/u/yymao/photoz-tutorial/tutorials/object_gcr_4_photoz.ipynb). I also plan to generate a rendered one and push to the orphan `rendered branch` (but this may not happen today).

I am creating this PR now so that people can have a chance to provide ideas. Right now the example is _very_ basic and I am sure people have better use cases to show. 