### PR TITLE
Fixing typo in cosmoDC2_TheMovie notebook

### DIFF
--- a/contributed/cosmoDC2_TheMovie.ipynb
+++ b/contributed/cosmoDC2_TheMovie.ipynb
@@ -265,7 +265,7 @@
     "\n",
     "plt.figure(figsize=(10, 7))\n",
     "\n",
-    "plt.bar(hp['loc'].bvalues, hp['count'].values, step, color='w', edgecolor='k')\n",
+    "plt.bar(hp['loc'].values, hp['count'].values, step, color='w', edgecolor='k')\n",
     "plt.xlabel(\"redshift\", fontsize=20)\n",
     "\n",
     "timer.split()"


### PR DESCRIPTION
This PR fixes a typo: `bvalues` -> `values` in one of the contributed notebooks and addresses #70. 