### PR TITLE
add ellipticity definition explanation in the FoF matching tutorial

### DIFF
--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -355,7 +355,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# load redshift and ellipticity from the extragalactic catalog, only for galaxise that are already in `matched_gals`\n",
+    "# load redshift and ellipticity from the extragalactic catalog, only for galaxies that are already in `matched_gals`\n",
     "extragalactic_data = extragalactic_cat.get_quantities(\n",
     "    ['galaxy_id', 'mag_i_lsst', 'ellipticity_true'],\n",
     "    filters=[(lambda x: np.in1d(x, matched_gals['object_id'].values, True), 'galaxy_id')]\n",

--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -414,12 +414,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# compare the ellipticity\n",
+    "# compare the ellipticity (naively -- see below for further discussion)\n",
     "plt.figure(figsize=(5,5));\n",
     "plt.scatter(matched_gals['ellipticity_true'], matched_gals['shape_hsm_regauss_etot'], s=1);\n",
     "lims = [0, 1]\n",
     "plt.plot(lims, lims, c='k', lw=0.5);\n",
     "plt.xlabel('extragalactic ellipticity');\n",
+    "plt.ylabel('object ellipticity');\n",
+    "plt.xlim(lims);\n",
+    "plt.ylim(lims);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ellipticity comparision plot is quite surprising. Not only they don't match, but it seems the ellipticity in the object catalog is higher when compared to that in the extragalactic catalog. If anything, the PSF should smear the ellipticity (making the value smaller) in the object catalog. \n",
+    "\n",
+    "We should however, remind ourselves the definition of ellipticity used in these catalogs. For the extragalactic catalog, ellipticity is defined as $(1-q)/(1+q)$ (see the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)). On the other hand, for the object catalog, we are using the HSM ellipticity that is defined as $(1-q^2)/(1+q^2)$. \n",
+    "\n",
+    "With some math, we can find the conversion between the two definition $e_{\\rm HSM~def} = \\frac{2e_{\\rm EGC~def}}{1+e_{\\rm EGC~def}^2}$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compare the ellipticity (smartly)\n",
+    "conversion = lambda e: 2*e / (1.0+e*e)\n",
+    "plt.figure(figsize=(5,5));\n",
+    "plt.scatter(conversion(matched_gals['ellipticity_true']), matched_gals['shape_hsm_regauss_etot'], s=1);\n",
+    "lims = [0, 1]\n",
+    "plt.plot(lims, lims, c='k', lw=0.5);\n",
+    "plt.xlabel('extragalactic ellipticity (in object def.)');\n",
     "plt.ylabel('object ellipticity');\n",
     "plt.xlim(lims);\n",
     "plt.ylim(lims);"

--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -355,9 +355,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# load redshift and shear parameters from the extragalactic catalog, only for galaxise that are already in `matched_gals`\n",
+    "# load redshift and ellipticity from the extragalactic catalog, only for galaxise that are already in `matched_gals`\n",
     "extragalactic_data = extragalactic_cat.get_quantities(\n",
-    "    ['galaxy_id', 'mag_i_lsst', 'ellipticity_true', 'shear_1', 'shear_2'],\n",
+    "    ['galaxy_id', 'mag_i_lsst', 'ellipticity_true'],\n",
     "    filters=[(lambda x: np.in1d(x, matched_gals['object_id'].values, True), 'galaxy_id')]\n",
     ")"
    ]
@@ -429,16 +429,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ellipticity comparison plot is quite surprising. \n",
-    "Not only they don't match, but it seems the ellipticity in the object catalog is higher when compared to that in the extragalactic catalog. \n",
-    "If anything, the PSF should smear the ellipticity (making the value smaller) in the object catalog. \n",
+    "The ellipticity comparison plot above is quite surprising. \n",
+    "It seems that the ellipticities in the object catalog are generally higher (i.e., less round) than those in the extragalactic catalog. \n",
     "\n",
-    "We should however, remind ourselves the definition of ellipticity used in these catalogs. \n",
-    "For the extragalactic catalog, ellipticity is defined as $(1-q)/(1+q)$\n",
+    "The quantity `shape_hsm_regauss_etot` that we used for the object catalog are the re-Gaussianization shapes, which are PSF corrected, and they could be either rounder (if the correction was an under-correction) or less round (if the correction was an over-correction). Hence, their value being systematically larger than the \"truth\" from extragalactic catalog seems problematic. \n",
+    "\n",
+    "Before we panic, we should, however, remind ourselves of the definition of ellipticities used in these catalogs. \n",
+    "For the extragalactic catalog, ellipticity is defined as $(1-q)/(1+q)$, where $q$ is the minor-to-major axis ratio\n",
     "(see the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)). \n",
-    "On the other hand, for the object catalog, we are using the HSM ellipticity that is defined as $(1-q^2)/(1+q^2)$\n",
+    "On the other hand, for the object catalog, the HSM re-Gaussianization ellipticity that we are using is defined as $(1-q^2)/(1+q^2)$\n",
     "(see e.g., Eq. 8 of [Mandelbaum et al. 2006](https://arxiv.org/abs/astro-ph/0511164)).\n",
     "\n",
+    "Hence their definitions are in fact different, so we need to do a conversion before we compare them.\n",
     "With some math, we can find the conversion between the two definitions $e_{\\rm HSM~def} = \\frac{2e_{\\rm EGC~def}}{1+e_{\\rm EGC~def}^2}$."
    ]
   },
@@ -449,9 +451,9 @@
    "outputs": [],
    "source": [
     "# compare the ellipticity (smartly)\n",
-    "conversion = lambda e: 2*e / (1.0+e*e)\n",
+    "ellipticity_conversion = lambda e: 2*e / (1.0+e*e)\n",
     "plt.figure(figsize=(5,5));\n",
-    "plt.scatter(conversion(matched_gals['ellipticity_true']), matched_gals['shape_hsm_regauss_etot'], s=1);\n",
+    "plt.scatter(ellipticity_conversion(matched_gals['ellipticity_true']), matched_gals['shape_hsm_regauss_etot'], s=1);\n",
     "lims = [0, 1]\n",
     "plt.plot(lims, lims, c='k', lw=0.5);\n",
     "plt.xlabel('extragalactic ellipticity (in object def.)');\n",
@@ -459,6 +461,89 @@
     "plt.xlim(lims);\n",
     "plt.ylim(lims);"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This looks much better now! \n",
+    "\n",
+    "When you were checking the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)) file,\n",
+    "you probably have also noticed that `ellipticity_true` is the ellipticity before the shear is applied (i.e., unlensed). \n",
+    "Hence this comparison is still not an apples-to-apples comparison, as the ellipticity in the object catalog is, of course, lensed. \n",
+    "\n",
+    "According to the the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)), we should have been using `ellipticity` from the extragalactic catalog.\n",
+    "But unfortunately, this quantity is not directly available from the extragalactic catalog!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "extragalactic_cat.has_quantity('ellipticity')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hmm, that's kind of sad, but luckily we can add our own derived quantities! "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calc_lensed_ellipticity(e1, e2, shear1, shear2):\n",
+    "    return np.hypot(e1+shear1, e2+shear2) \n",
+    "    \n",
+    "extragalactic_cat.add_derived_quantity('ellipticity', calc_lensed_ellipticity, \n",
+    "                                       'ellipticity_1_true', 'ellipticity_2_true', 'shear_1', 'shear_2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now let's get the newly defined ellipticity and add to our merged pandas data frame:\n",
+    "extragalactic_data_more = extragalactic_cat.get_quantities(\n",
+    "    ['galaxy_id', 'ellipticity'],\n",
+    "    filters=[(lambda x: np.in1d(x, matched_gals['object_id'].values, True), 'galaxy_id')]\n",
+    ")\n",
+    "\n",
+    "matched_gals = pd.merge(matched_gals, pd.DataFrame(extragalactic_data_more), 'left', left_on='object_id', right_on='galaxy_id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Now we compare the ellipticity again (and don't forget the definition conversion!)\n",
+    "ellipticity_conversion = lambda e: 2*e / (1.0+e*e)\n",
+    "plt.figure(figsize=(5,5));\n",
+    "plt.scatter(ellipticity_conversion(matched_gals['ellipticity']), matched_gals['shape_hsm_regauss_etot'], s=1);\n",
+    "lims = [0, 1]\n",
+    "plt.plot(lims, lims, c='k', lw=0.5);\n",
+    "plt.xlabel('extragalactic ellipticity (lensed, in object def.)');\n",
+    "plt.ylabel('object ellipticity');\n",
+    "plt.xlim(lims);\n",
+    "plt.ylim(lims);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -472,7 +472,7 @@
     "you probably have also noticed that `ellipticity_true` is the ellipticity before the shear is applied (i.e., unlensed). \n",
     "Hence this comparison is still not an apples-to-apples comparison, as the ellipticity in the object catalog is, of course, lensed. \n",
     "\n",
-    "According to the the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)), we should have been using `ellipticity` from the extragalactic catalog.\n",
+    "According to the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)), we should have been using `ellipticity` from the extragalactic catalog.\n",
     "But unfortunately, this quantity is not directly available from the extragalactic catalog!"
    ]
   },

--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -498,11 +498,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def calc_lensed_ellipticity(e1, e2, shear1, shear2):\n",
-    "    return np.hypot(e1+shear1, e2+shear2) \n",
+    "def calc_lensed_ellipticity(es1, es2, gamma1, gamma2, kappa):\n",
+    "    gamma = gamma1 + gamma2*1j # shear (as a complex number)\n",
+    "    es = es1 + es2*1j # intrinsic ellipticity (as a complex number)\n",
+    "    g = gamma / (1.0 - kappa) # reduced shear\n",
+    "    e = (es + g) / (1.0 + g.conjugate()*es) # lensed ellipticity\n",
+    "    return np.absolute(e)\n",
     "    \n",
     "extragalactic_cat.add_derived_quantity('ellipticity', calc_lensed_ellipticity, \n",
-    "                                       'ellipticity_1_true', 'ellipticity_2_true', 'shear_1', 'shear_2')"
+    "                                       'ellipticity_1_true', 'ellipticity_2_true', 'shear_1', 'shear_2', 'convergence')"
    ]
   },
   {

--- a/tutorials/matching_fof.ipynb
+++ b/tutorials/matching_fof.ipynb
@@ -429,11 +429,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ellipticity comparision plot is quite surprising. Not only they don't match, but it seems the ellipticity in the object catalog is higher when compared to that in the extragalactic catalog. If anything, the PSF should smear the ellipticity (making the value smaller) in the object catalog. \n",
+    "The ellipticity comparison plot is quite surprising. \n",
+    "Not only they don't match, but it seems the ellipticity in the object catalog is higher when compared to that in the extragalactic catalog. \n",
+    "If anything, the PSF should smear the ellipticity (making the value smaller) in the object catalog. \n",
     "\n",
-    "We should however, remind ourselves the definition of ellipticity used in these catalogs. For the extragalactic catalog, ellipticity is defined as $(1-q)/(1+q)$ (see the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)). On the other hand, for the object catalog, we are using the HSM ellipticity that is defined as $(1-q^2)/(1+q^2)$. \n",
+    "We should however, remind ourselves the definition of ellipticity used in these catalogs. \n",
+    "For the extragalactic catalog, ellipticity is defined as $(1-q)/(1+q)$\n",
+    "(see the [SCHEMA](https://github.com/LSSTDESC/gcr-catalogs/blob/master/GCRCatalogs/SCHEMA.md#schema-for-extragalatic-catalogs)). \n",
+    "On the other hand, for the object catalog, we are using the HSM ellipticity that is defined as $(1-q^2)/(1+q^2)$\n",
+    "(see e.g., Eq. 8 of [Mandelbaum et al. 2006](https://arxiv.org/abs/astro-ph/0511164)).\n",
     "\n",
-    "With some math, we can find the conversion between the two definition $e_{\\rm HSM~def} = \\frac{2e_{\\rm EGC~def}}{1+e_{\\rm EGC~def}^2}$"
+    "With some math, we can find the conversion between the two definitions $e_{\\rm HSM~def} = \\frac{2e_{\\rm EGC~def}}{1+e_{\\rm EGC~def}^2}$."
    ]
   },
   {


### PR DESCRIPTION
This PR fixes #76. See the new plot in #76. 

Probably need to add a reference on where the HSM ellipticity definition comes from (added).