### PR TITLE
Update the link to sky map notebook in GCR part 1 notebook

### DIFF
--- a/tutorials/object_gcr_1_intro.ipynb
+++ b/tutorials/object_gcr_1_intro.ipynb
@@ -131,7 +131,7 @@
     "<img src=\"assets/dc2_skymap.png\">\n",
     "Here the tracts have large blue numbers, and the patches are denoted with an `(x,y)` format. For DC2, each tract has 8x8 patches.\n",
     "\n",
-    "You can learn more about how to make such a plot of the tract and patches [here](Plotting_the_Run1.1p_skymap.ipynb)\n",
+    "You can learn more about how to make such a plot of the tract and patches [here](dm_butler_skymap.ipynb)\n",
     "\n",
     "The **GCR object catalog preserves this structure of the data** so that any particular quantity can be accessed on a tract/patch bases. The tracts available in the catalog can be listed using the following command:"
    ]


### PR DESCRIPTION
This PR updates the link to the sky map notebook in the GCR part 1 notebook to fix #81. Thanks @djperrefort for noticing the broken link. 