### PR TITLE
first stab at updates for move from Calib to PhotoCalib

### DIFF
--- a/tutorials/dm_butler_lensing_cuts.ipynb
+++ b/tutorials/dm_butler_lensing_cuts.ipynb
@@ -95,8 +95,7 @@
     "        # continue looping over the patches.\n",
     "        try:\n",
     "            forced = butler.get('deepCoadd_forced_src', dataId)\n",
-    "            calib = butler.get('deepCoadd_calexp_calib', dataId)\n",
-    "            calib.setThrowOnNegativeFlux(False)\n",
+    "            calib = butler.get('deepCoadd_calexp_photoCalib', dataId)\n",
     "            merged = butler.get('deepCoadd_ref', dataId)\n",
     "        except dp.NoResults as eobj:\n",
     "            print(eobj)\n",
@@ -279,7 +278,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As mentioned in #85, the afw interface for Calib has moved to PhotoCalib.  Initial changes have been made, but held off modifying calls to `getMagnitude` for now.  