### PR TITLE
U/jrbogart/postgres run21i dr1b v1

### DIFF
--- a/tutorials/postgres_object_1_intro.ipynb
+++ b/tutorials/postgres_object_1_intro.ipynb
@@ -14,7 +14,7 @@
     "Owner: **Joanne Bogart [@jrbogart](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@jrbogart)**  \n",
     "Last Verified to Run: \n",
     "\n",
-    "This notebook is an introduction to use of the PostgreSQL database at NERSC.  Currently the only fully supported datasets are the object catalogs for Run1.2i and Run1.2p v4. Since object catalogs as well as other kinds of catalogs are also available via GCR one might question the need for another form of access.  The justification (for those applications only using object catalogs) is performance. Typical queries such as the one labeled `q5` below run significantly faster.  Ingest also tends to be faster. The Run1.2p v4 data was available via PostgreSQL within a day of the completion of stack processing and transfer to NERSC.\n",
+    "This notebook is an introduction to use of the PostgreSQL database at NERSC.  Currently the fully supported datasets are the object catalogs for Run1.2i, Run1.2p v4, and run2.1i dr1b v1. Since object catalogs as well as other kinds of catalogs are also available via GCR one might question the need for another form of access.  The justification (for those applications only using object catalogs) is performance. Typical queries such as the one labeled `q5` below run significantly faster.  Ingest also tends to be faster. The Run1.2p v4 data were available via PostgreSQL within a day of the completion of stack processing and transfer to NERSC.\n",
     "\n",
     "__Learning objectives__:\n",
     "\n",
@@ -85,7 +85,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "schema = 'run12i'   # change value to 'run12p_v4' for the Run 1.2p catalog "
+    "schema = 'run12i'   \n",
+    "# schema = 'run12p_v4'\n",
+    "# schema = 'run21i_dr1b_v1'"
    ]
   },
   {
@@ -233,7 +235,7 @@
     "### Color-color\n",
     "Techniques are adapted from the notebook [object_pandas_stellar_locus](https://github.com/LSSTDESC/DC2-analysis/blob/master/tutorials/object_pandas_stellar_locus.ipynb).\n",
     "#### Using cuts\n",
-    "Put some typical cuts in a WHERE clause: select `clean` objects (no flagged pixels; not skipped by deblender) for which signal to noise in bands of interest is acceptable.\n"
+    "Put some typical cuts in a WHERE clause: select `clean` objects (no flagged pixels; not skipped by deblender) for which signal to noise in bands of interest is acceptable."
    ]
   },
   {
@@ -277,7 +279,7 @@
     "def get_stellar_locus_davenport(color1='gmr', color2='rmi',\n",
     "                                datafile='../tutorials/assets/Davenport_2014_MNRAS_440_3430_table1.txt'):\n",
     "                                #datafile='assets/Davenport_2014_MNRAS_440_3430_table1.txt'):\n",
-    "    data = pd.read_table(datafile, sep='\\s+', header=1)\n",
+    "    data = pd.read_csv(datafile, sep='\\s+', header=1)\n",
     "    return data[color1], data[color2]\n",
     "    \n",
     "    \n",
@@ -334,7 +336,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now make the same plot, but for Run 1.2p data.  The query takes noticeably longer because the Run 1.2p catalog is about 5 times bigger than the one for Run 1.2i."
+    "Now make the same plot, but for Run 1.2p data.  The query takes noticeably longer because the Run 1.2p catalog is about 5 times bigger than the one for Run 1.2i. For Run 2.1i dr1b v1 it takes over 30 minutes."
    ]
   },
   {
@@ -377,9 +379,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-python",
+   "display_name": "desc-python-old",
    "language": "python",
-   "name": "desc-python"
+   "name": "desc-python-old"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/postgres_object_1_intro.ipynb
+++ b/tutorials/postgres_object_1_intro.ipynb
@@ -379,9 +379,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-python-old",
+   "display_name": "desc-python",
    "language": "python",
-   "name": "desc-python-old"
+   "name": "desc-python"
   },
   "language_info": {
    "codemirror_mode": {

--- a/tutorials/postgres_object_2.ipynb
+++ b/tutorials/postgres_object_2.ipynb
@@ -83,12 +83,13 @@
    "outputs": [],
    "source": [
     "cols = ['schema_name', 'run_designation','simulation_program', 'db_ingest', 'remarks']\n",
+    "hdrs = ['schema_name', 'run_desig', 'sim_prog','db_ingest', 'remarks']\n",
     "# Additional columns in run_provenance store software and input data versions\n",
     "prov_query = 'SELECT '  + ','.join(cols) + ' from run_provenance'\n",
     "with dbconn.cursor() as cursor:\n",
     "    cursor.execute(prov_query)\n",
-    "    fmt = '{0!s:13} {1!s:16} {2!s:18} {3!s:12} {4!s}'\n",
-    "    print(fmt.format(cols[0], cols[1], cols[2], cols[3], cols[4]))\n",
+    "    fmt = '{0!s:14} {1!s:10} {2!s:9} {3!s:15} {4!s}'\n",
+    "    print(fmt.format(hdrs[0], hdrs[1], hdrs[2], hdrs[3], hdrs[4]))\n",
     "    for record in cursor:\n",
     "        print(fmt.format(record[0], record[1], record[2], record[3], record[4]))"
    ]
@@ -97,7 +98,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Normally only data sets with `db_ingest` == 'complete' are of interest"
+    "Normally only datasets where the `db_ingest` field contains 'complete' are of interest"
    ]
   },
   {
@@ -147,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now suppose we wanted to combine a cut on this quantity, in table dpdd_ref, with cuts on DPDD quantities like `clean`.  Then the query has to be made on a join of these two tables, where we specify that the value of dpdd_ref.object_id = dpdd.objectid. This causes the corresponding rows from each table (or view) to be treated as if they were assembled into one long row. Here is a simple query showing how this is done. A more realistic one would have more conditions in the `where` clause and might join more than two tables."
+    "Now suppose we wanted to combine a cut on this quantity, in table dpdd_ref, with cuts on DPDD quantities like `clean`.  Then the query has to be made on a join of these two tables, where we specify that the value of dpdd_ref.object_id = dpdd.objectid. This causes the corresponding rows from each table (or view) to be treated as if they were assembled into one long row. Here is a simple query showing how this is done. A more realistic one would have more conditions in the `where` clause and might join more than two tables.  "
    ]
   },
   {
@@ -157,16 +158,57 @@
    "outputs": [],
    "source": [
     "schema = 'run12i'\n",
-    "join_query = 'select count(object_id) from {schema}.dpdd_ref join {schema}.dpdd '\n",
+    "join_query = 'select count(object_id) from {schema}.dpdd join {schema}.dpdd_ref '\n",
     "join_query += 'on {schema}.dpdd_ref.object_id = {schema}.dpdd.objectid'\n",
     "join_query = join_query.format(**locals())\n",
     "where = \" where (ext_shapeHSM_HSmShapeRegauss_flag = 'f') and clean\"\n",
     "join_query += where\n",
     "print(join_query)                # confirm the query looks reasonable\n",
     "with dbconn.cursor() as cursor:\n",
-    "    cursor.execute(join_query)\n",
+    "    %time cursor.execute(join_query)\n",
     "    for record in cursor:\n",
     "        print(record[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adjustments for Larger Datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the above query I switched to a different, significantly smaller dataset (2.8 million objects rather than 13.7 million).  For the much larger 2.1i_dr1b_v1 (over 78 million objects) we have to pay some attention to performance.\n",
+    "The dpdd view is formed from a join of 3 tables. **dpdd_ref** is one of them, so in the above query that table is joined to itself, increasing the resources needed to make the query unnecessarily.  It's more efficient to just get all quantities from a join of tables only, but the dpdd view is more than just the result of a join with some of the columns renamed.  `clean` is formed by doing logical operations on several native-quantity flags. Starting with run 2.1i_dr1b_v1 it can be expressed as ```good and not deblend_skipped``` where both `good` and `deblend_skipped` are columns in **dpdd_ref**. (In earlier runs, `good` existed only in the dpdd view as the result of logical operations on several native-quantity flags).  We also have to exclude non-primary objects, as the dpdd view does.  The flag `detect_isprimary` is in the **position** table. The query for run 2.1i_dr1b_v1 can be written as shown in the next cell. Skip it if you're in a hurry; even with these techniques it still takes about 13 minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema = 'run21i_dr1b_v1'\n",
+    "join_query = 'select count(position.object_id) from {schema}.position left join {schema}.dpdd_ref '\n",
+    "join_query += 'on {schema}.position.object_id = {schema}.dpdd_ref.object_id'\n",
+    "join_query = join_query.format(**locals())\n",
+    "where = \" where detect_isprimary and good and (not deblend_skipped) and (ext_shapeHSM_HSmShapeRegauss_flag = 'f')\"\n",
+    "join_query += where\n",
+    "print(join_query)                # confirm the query looks reasonable\n",
+    "with dbconn.cursor() as cursor:\n",
+    "    %time cursor.execute(join_query)\n",
+    "    for record in cursor:\n",
+    "        print(record[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In all such joins, **position** should be the first table in the join and left joins should be used, as in the example. This will in general result in better performance since it forces the join(s) to be done in the order specified. All tables are indexed on `object_id`. Only the **position** table has additional indexes (on `detect_isprimary` and on `coord`, a special column used in area searches)."
    ]
   },
   {
@@ -195,7 +237,37 @@
     "--------\n",
     " 233982\n",
     "(1 row)\n",
-    "```"
+    "```\n",
+    "### Restricting by tract or patch\n",
+    "\n",
+    "Let's try the last query from the previous section restriced to tract 3446 (picked at random), which has about 570,000 objects. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schema = 'run21i_dr1b_v1'\n",
+    "join_query = 'select count(position.object_id) from {schema}.position left join {schema}.dpdd_ref '\n",
+    "join_query += 'on {schema}.position.object_id = {schema}.dpdd_ref.object_id'\n",
+    "join_query = join_query.format(**locals())\n",
+    "where = \" where detect_isprimary and tractsearch(position.object_id, 3446) and  \"\n",
+    "where += \"good and (not deblend_skipped) and (ext_shapeHSM_HSmShapeRegauss_flag = 'f')\"\n",
+    "join_query += where\n",
+    "print(join_query)                # confirm the query looks reasonable\n",
+    "with dbconn.cursor() as cursor:\n",
+    "    %time cursor.execute(join_query)\n",
+    "    for record in cursor:\n",
+    "        print(record[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " Tract 3446 has about 1/136 of the objects in the run21i_dr1b_v1 dataset. The elapsed time for the tract query (2 or 3 seconds) is much less than 1/136 of the time taken by the original query (780 seconds/ 136 = about 5.7 seconds). It pays to restrict queries to a tract when possible, even if it means issuing the same query for several tracts. "
    ]
   },
   {
@@ -221,7 +293,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "schema = 'run12p_v4'\n",
+    "schema = 'run21i_dr1b_v1'\n",
     "band = 'i'\n",
     "mag_col = 'mag_' + band\n",
     "min_SNR = 25   \n",
@@ -323,7 +395,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The two tutorials concerning accessing the object catalog via Postgres have been updated for use with Run2.1i dr1b v1 (as well as Run1.2i and Run1.2p v4).  The intro notebook has only minor changes. Part 2 has new sections explaining new techniques for large datasets.