### PR TITLE
Issues/101 - Include CosmoDC2 population comparison

### DIFF
--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -253,6 +253,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sampling_factor = 100\n",
+    "cosmoDC2_subsample = (lambda x: x % sampling_factor == remainder, 'galaxy_id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "cosmoDC2_cat = GCRCatalogs.load_catalog('cosmoDC2')"
    ]
   },

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Inspection of DC2 Run 2.1i Object Table \n",
     "### Michael Wood-Vasey (@wmwv)\n",
-    "### Last Verified to Run: 2019-07-16\n",
+    "### Last Verified to Run: 2019-07-22\n",
     "\n",
     "Inspect the Run 2.1i DR1 Object Table for DR1*\n",
     "\n",
@@ -28,7 +28,13 @@
     "  * 78 million objects  \n",
     "  * 48 million objects with i-band SNR > 5\n",
     "\n",
-    "Loading the entire catalog takes ~15 minutes, depending on memory load on the JupyterHub node.  We've thus entered an era where it will be common to only look at subsamples of the full DC2 datasets, whether that's considering just one tract, or taking a subsample of the full catalog."
+    "Loading the entire catalog takes ~15 minutes, depending on memory load on the JupyterHub node.  We've thus entered an era where it will be common to only look at subsamples of the full DC2 datasets, whether that's considering just one tract, or taking a subsample of the full catalog.\n",
+    "\n",
+    "#### Quick Data Size estimates\n",
+    "\n",
+    "Loading 1 column stored as 64-bit floats on 64 million objects takes 512 MB of memory:\n",
+    "\n",
+    "8 bytes/column/row * 1 column * 64 million rows = 2^3 * 2^0 * 2^6 million bytes (MB) = 2^9 MB = 512 MB"
    ]
   },
   {
@@ -95,11 +101,11 @@
    "outputs": [],
    "source": [
     "# For testing one may find it useful to load just one tract:\n",
-    "catalog_name = 'dc2_object_run2.1i_dr1_tract3830'\n",
+    "# catalog_name = 'dc2_object_run2.1i_dr1_tract_3830'\n",
+    "catalog_name = 'dc2_object_run2.1i_dr1'\n",
     "# To see the full RA, Dec distribution, load the full catalog.\n",
     "# Going through whole catalog will take 5-10 minutes to go through each of the files,\n",
-    "# regardless of the subsampling chosen (see next cell)\n",
-    "# catalog_name = 'dc2_object_run2.1i_dr1'"
+    "# regardless of the subsampling chosen (see next cell)"
    ]
   },
   {
@@ -110,7 +116,7 @@
    "source": [
     "# Sampling must be an positive integer.\n",
     "# To reduce subsequent arithmetic demands on your brain I would recommend picking a power of ten.\n",
-    "sampling_factor = 1"
+    "sampling_factor = 10"
    ]
   },
   {
@@ -162,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = GCRCatalogs.load_catalog(catalog_name)"
+    "cat = GCRCatalogs.load_catalog(catalog_name, config_overwrite={'use_cache': False})"
    ]
   },
   {
@@ -172,8 +178,6 @@
    "outputs": [],
    "source": [
     "columns = ['ra', 'dec']\n",
-    "columns += [f'psFlux_{f}' for f in filters]\n",
-    "columns += [f'psFluxErr_{f}' for f in filters]\n",
     "columns += [f'mag_{f}' for f in filters]\n",
     "columns += [f'magerr_{f}' for f in filters]\n",
     "columns += [f'mag_{f}_cModel' for f in filters]\n",
@@ -183,6 +187,17 @@
     "columns += [f'Iyy_{f}' for f in filters]\n",
     "columns += [f'psf_fwhm_{f}' for f in filters]\n",
     "columns += ['good', 'extendedness', 'blendedness']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MB_per_column = 512  # MB / column / 64 million rows\n",
+    "print(f'We are going to load {len(columns)} columns.')\n",
+    "print(f'For {64/sampling_factor} million rows that should take {len(columns)*MB_per_column/sampling_factor/1024} GB of memory')"
    ]
   },
   {
@@ -253,17 +268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampling_factor = 100\n",
-    "cosmoDC2_subsample = (lambda x: x % sampling_factor == remainder, 'galaxy_id')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cosmoDC2_cat = GCRCatalogs.load_catalog('cosmoDC2')"
+    "cosmoDC2_cat = GCRCatalogs.load_catalog('cosmoDC2', config_overwrite={'use_cache': False})"
    ]
   },
   {
@@ -280,6 +285,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Loaded {len(cosmoDC2)} objects from \"cosmocDC2\" with a subsampling of {sampling_factor}x')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -293,7 +307,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hsc_cat = GCRCatalogs.load_catalog('hsc-pdr1-xmm')"
+    "hsc_cat = GCRCatalogs.load_catalog('hsc-pdr1-xmm',\n",
+    "                                   config_overwrite={'base_dir': '/global/cscratch1/sd/desc/hsc',\n",
+    "                                                    'use_cache': False})"
    ]
   },
   {
@@ -580,14 +596,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# We use the assets in `tutorials/assets' for the stellar-locus because it's the same file.\n",
+    "# We refer to a file over in `tutorials/assets' for the stellar locus\n",
     "datafile_davenport = '../tutorials/assets/Davenport_2014_MNRAS_440_3430_table1.txt'\n",
     "\n",
     "def get_stellar_locus_davenport(color1='gmr', color2='rmi',\n",
     "                                datafile=datafile_davenport):\n",
     "    data = pd.read_table(datafile, sep='\\s+', header=1)\n",
     "    return data[color1], data[color2]\n",
-    "    \n",
+    "\n",
     "    \n",
     "def plot_stellar_locus(color1='gmr', color2='rmi',\n",
     "                       color='red', linestyle='--', linewidth=2.5,\n",
@@ -771,65 +787,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hsc_cat = GCRCatalogs.load_catalog('hsc-pdr1-xmm')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Establish some basic cuts intended to yield a galaxy sample with reasonable flux measurements.\n",
-    "basic_cuts = [\n",
-    "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
-    "                       # and was not skipped by the deblender\n",
-    "    GCRQuery('xy_flag == 0'),                                      # Flag for bad centroid measurement\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Define cuts on galaxy properties: currently we simply make a sample limited at i<25.\n",
-    "# This implicitly requires the magnitude to be finite.\n",
-    "max_mag_i = 25\n",
-    "properties_cuts = [\n",
-    "    GCRQuery(f'mag_i_cModel < {max_mag_i}'),\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hsc = pd.DataFrame(hsc_cat.get_quantities(['extendedness', 'ra', 'dec', 'mag_i', 'mag_i_cModel'],\n",
-    "                                          filters=basic_cuts + properties_cuts))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# We could of course done this as part of a GCR query.\n",
-    "# But using a query in the DataFrame is how we did the `stars`, `galaxies` selection above, so we'll do it the same way here.\n",
-    "hsc_stars = hsc[hsc['extendedness'] == 0]\n",
-    "hsc_galaxies = hsc[hsc['extendedness'] > 0]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -971,7 +928,9 @@
    "source": [
     "## Blendedness\n",
     "\n",
-    "Blendedness is a measure of whether the identified flux from the object overlaps with the flux from another object."
+    "Blendedness is a measure of how much the identified flux from an object is affected by overlapping from other objects.\n",
+    "\n",
+    "See Bosch et al., 2018, Section 4.9.11."
    ]
   },
   {

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -110,7 +110,7 @@
    "source": [
     "# Sampling must be an positive integer.\n",
     "# To reduce subsequent arithmetic demands on your brain I would recommend picking a power of ten.\n",
-    "sampling_factor = 100"
+    "sampling_factor = 10"
    ]
   },
   {
@@ -950,7 +950,8 @@
     "plt.legend(loc='upper left')\n",
     "plt.xlabel('i-band magnitude')\n",
     "plt.ylabel('normalized distribution')\n",
-    "plt.yscale('log')"
+    "plt.yscale('log')\n",
+    "plt.savefig('dc2_object_run2.1i_cosmoDC2_HSC_galaxy_counts.pdf')"
    ]
   },
   {

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Inspection of DC2 Run 2.1i Object Table \n",
     "### Michael Wood-Vasey (@wmwv)\n",
-    "### Last Verified to Run: 2019-07-22\n",
+    "### Last Verified to Run: 2019-08-09\n",
     "\n",
     "Inspect the Run 2.1i DR1 Object Table for DR1*\n",
     "\n",
@@ -28,7 +28,7 @@
     "  * 78 million objects  \n",
     "  * 48 million objects with i-band SNR > 5\n",
     "\n",
-    "Loading the entire catalog takes ~15 minutes, depending on memory load on the JupyterHub node.  We've thus entered an era where it will be common to only look at subsamples of the full DC2 datasets, whether that's considering just one tract, or taking a subsample of the full catalog.\n",
+    "Loading the entire catalog takes ~15 minutes, depending on memory load on the JupyterHub node.  It thus is often most useful to develop ones codes looking at only subsamples of the full DC2 datasets, whether that's considering just one tract, or taking a subsample of the full catalog.\n",
     "\n",
     "#### Quick Data Size estimates\n",
     "\n",
@@ -83,7 +83,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# cmap = 'Oranges'\n",
     "cmap = 'viridis_r'"
    ]
   },
@@ -105,7 +104,7 @@
     "# To see the full RA, Dec distribution, load the full catalog.\n",
     "catalog_name = 'dc2_object_run2.1i_dr1'\n",
     "\n",
-    "# Going through whole catalog will take 5-10 minutes to go through each of the files,\n",
+    "# Going through whole catalog will take 5-10 minutes,\n",
     "# regardless of the subsampling chosen (see next cell)"
    ]
   },
@@ -333,8 +332,8 @@
     "    GCRQuery('xy_flag == 0'),                                      # Flag for bad centroid measurement\n",
     "]\n",
     "\n",
-    "# Define cuts on galaxy properties: currently we simply make a sample limited at i<25.\n",
-    "# This implicitly requires the magnitude to be finite.\n",
+    "# Define cuts on object properties: currently we simply make a sample limited at i<25.\n",
+    "# This implicitly also requires the magnitude to be finite.\n",
     "max_mag_i = 25\n",
     "properties_cuts = [\n",
     "    GCRQuery(f'mag_i_cModel < {max_mag_i}'),\n",
@@ -370,7 +369,6 @@
     "                                          filters=basic_cuts + properties_cuts))\n",
     "\n",
     "# We could of course done this as part of a GCR query.\n",
-    "# But using a query in the DataFrame is how we did the `stars`, `galaxies` selection above, so we'll do it the same way here.\n",
     "hsc_stars = hsc[hsc['extendedness'] == 0]\n",
     "hsc_galaxies = hsc[hsc['extendedness'] > 0]"
    ]
@@ -426,7 +424,7 @@
     "    ax.set_aspect(1)\n",
     "\n",
     "    plt.hist2d(cat['ra'], cat['dec'], bins=100)\n",
-    "    plt.xlim(plt.xlim()[::-1])  # Flip to East left\n",
+    "    ax.invert_xaxis()  # Flip to East left\n",
     "    plt.xlabel('RA [deg]')\n",
     "    plt.ylabel('Dec [deg]')\n",
     "    plt.colorbar(shrink=0.5, label='objects / bin')\n",
@@ -464,7 +462,7 @@
     "\n",
     "Notes:\n",
     "* We're missing the DDF region, which was specifically not included in this DR1 coadd.\n",
-    "* We're missing a bit of the South-West (lower-left, \"North Up, East Left\") corner.\n",
+    "* We're missing a bit of the South-West (lower-right, \"North Up, East Left\") corner.\n",
     "* There are also a few patches that failed within the main region.\n",
     "* There is an overall gradient N/S in object density, because we're plotting in rectilinear RA, Dec bins, which means that bins at the bottom in RA cover less area than those at the top.\n",
     "\n",
@@ -710,6 +708,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plot_four_color_color(hsc_stars)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The stellar locus in the HSC data looks very good."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "------\n",
+    "Let's plot the galaxies on the same color-color plots\n",
+    "\n",
+    "Clearly one doesn't expect the galaxies to follow the stellar locus.  But including the stellar locus lines makes it easy to guide the eye between the stars-only and the galaxies-only plots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plot_four_color_color(galaxies)"
    ]
   },
@@ -728,14 +752,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_four_color_color(hsc)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Clearly one doesn't expect the galaxies to follow the stellar locus.  The lines above are include to more easily guide the eye between the stars-only and the galaxies-only plots."
+    "plot_four_color_color(hsc_galaxies)"
    ]
   },
   {
@@ -744,7 +761,7 @@
    "source": [
     "Questions for further study:\n",
     "   1. Is there a better comparison sample for the stellar locus than the Davenport reference?\n",
-    "   2. Why is the stellar locus in the Davenport redder than the observed data.  Are there different extinction assumptions (this should be a low-extinction region).  Are there different bandpasses used?"
+    "   2. Why is the stellar locus in the Davenport 0.1--0.2 mag redder for the reddest stars than the observed data.  Are there different extinction assumptions (this should be a low-extinction region).  Are there different bandpasses used?"
    ]
   },
   {
@@ -760,17 +777,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_mag(filt, ax=None):\n",
+    "def plot_mag(filt, log=True, range=(16, 28), ax=None, ):\n",
     "    if ax is None:\n",
     "        ax = fig.gca()\n",
     "    mag = f'mag_{filt}'\n",
     "    ax.hist([good[mag], stars[mag], galaxies[mag]],\n",
-    "             label=['all', 'star', 'galaxy'],\n",
-    "             range=(16, 30),\n",
-    "             bins=np.linspace(16, 30, 100),\n",
-    "             histtype='step')\n",
+    "            label=['all', 'star', 'galaxy'],\n",
+    "            log=log,\n",
+    "            range=range,\n",
+    "            bins=np.linspace(*range, 100),\n",
+    "            histtype='step')\n",
     "    ax.set_xlabel(filt)\n",
     "    ax.set_ylabel('objects / bin')\n",
+    "    ax.set_xlim(range)\n",
+    "    ax.set_ylim(bottom=10)\n",
     "    ax.legend(loc='upper left')\n",
     "\n",
     "fig, axes = plt.subplots(2, 3, figsize=(12, 6))\n",
@@ -782,7 +802,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The sharp cut in i-band is because that was the reference band for most detections.  The u- and y-band distributions extend to 30th because most of them are non-detections."
+    "The sharp cut in i-band is because that was the reference band for most detections.  The distributions in the other bands extend to 28th mag because many of the forced-photometry measurements are consistent with 0."
    ]
   },
   {
@@ -1148,6 +1168,7 @@
    "metadata": {},
    "source": [
     "## Shape Parameters\n",
+    "\n",
     "Ixx, Iyy, Ixy"
    ]
   },
@@ -1257,7 +1278,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## FWHM"
+    "### FWHM of the PSF\n",
+    "At the location of the catalog objects.\n",
+    "\n",
+    "The Object Table stores the shape parameters of the PSF model as evaluated at the location of the object.\n",
+    "\n",
+    "This is not the same as, but is certainly related to, the distribution of effective seeing in the individual images that made up the coadd."
    ]
   },
   {
@@ -1273,7 +1299,7 @@
     "        w, = np.where(np.isfinite(psf_fwhm))\n",
     "        sns.distplot(psf_fwhm[w], label=filt, color=color)\n",
     "    plt.xlabel('PSF FWHM [arcsec]')\n",
-    "    plt.ylabel('objects density / bin')\n",
+    "    plt.ylabel('normalized object density')\n",
     "    plt.legend()"
    ]
   },
@@ -1284,6 +1310,23 @@
    "outputs": [],
    "source": [
     "plot_psf_fwhm()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see here that the model PSF FWHM from the coadd achieves the best seeing in r and i.  Providing the best seeing in r and i is one of the goals of the observation planning, so this part looks successful."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Questions for further investigation:\n",
+    "1. How do the above distributions of PSF FWHM compare to the effective per-visit seeing?\n",
+    "2. How do the above distributions of PSF FWHM compare to the OpSim simulation, minion_1016, used to generated DC2 Run 2.1i?\n",
+    "3. Are the model PSFs from the coadd reasonable?  The coadds are generated by combining the individual images -- that may not result in PSFs that coherently make sense across a given region of the coadd, particularly as more and more objects are intersected by CCD boundaries and gaps."
    ]
   },
   {
@@ -1314,5 +1357,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -101,11 +101,19 @@
    "outputs": [],
    "source": [
     "# For testing one may find it useful to load just one tract:\n",
-    "# catalog_name = 'dc2_object_run2.1i_dr1_tract_3830'\n",
-    "catalog_name = 'dc2_object_run2.1i_dr1'\n",
+    "# catalog_name = 'dc2_object_run2.1i_dr1_tract3830'\n",
     "# To see the full RA, Dec distribution, load the full catalog.\n",
+    "catalog_name = 'dc2_object_run2.1i_dr1'\n",
+    "\n",
     "# Going through whole catalog will take 5-10 minutes to go through each of the files,\n",
     "# regardless of the subsampling chosen (see next cell)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that once we're loading the full CosmoDC2 catalog below the dominant time usage is loading that catalog, not the DC2 Run 2.1i Object catalog."
    ]
   },
   {
@@ -116,7 +124,7 @@
    "source": [
     "# Sampling must be an positive integer.\n",
     "# To reduce subsequent arithmetic demands on your brain I would recommend picking a power of ten.\n",
-    "sampling_factor = 10"
+    "sampling_factor = 100"
    ]
   },
   {

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -240,6 +240,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Need to use 'galaxy_id' instead of 'objectId'\n",
+    "if subsample is None:\n",
+    "    cosmoDC2_subsample = None\n",
+    "else:\n",
+    "    cosmoDC2_subsample = (lambda x: x % sampling_factor == remainder, 'galaxy_id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "cosmoDC2_cat = GCRCatalogs.load_catalog('cosmoDC2')"
    ]
   },
@@ -253,7 +266,7 @@
     "max_mag_i = 25\n",
     "mag_limit_filter = [GCRQuery(f'mag_i < {max_mag_i}')]\n",
     "cosmoDC2 = pd.DataFrame(cosmoDC2_cat.get_quantities(cosmoDC2_columns,\n",
-    "                                                    filters=[subsample] + mag_limit_filter))"
+    "                                                    filters=[cosmoDC2_subsample] + mag_limit_filter))"
    ]
   },
   {
@@ -292,15 +305,6 @@
     "properties_cuts = [\n",
     "    GCRQuery(f'mag_i_cModel < {max_mag_i}'),\n",
     "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print([c for c in hsc_cat.list_all_quantities() if re.match('mag_', c)])"
    ]
   },
   {
@@ -911,8 +915,8 @@
    "outputs": [],
    "source": [
     "num_den_dc2 = sampling_factor * len(galaxies) / area_dc2\n",
+    "num_den_cosmoDC2 = sampling_factor * len(cosmoDC2) / area_cosmoDC2\n",
     "num_den_hsc = len(hsc) / area_hsc\n",
-    "num_den_cosmoDC2 = len(cosmoDC2) / area_cosmoDC2\n",
     "\n",
     "# Change default expression to 1/arcmin**2\n",
     "num_den_dc2 = num_den_dc2.to(1/u.arcmin**2)\n",

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -110,7 +110,7 @@
    "source": [
     "# Sampling must be an positive integer.\n",
     "# To reduce subsequent arithmetic demands on your brain I would recommend picking a power of ten.\n",
-    "sampling_factor = 1"
+    "sampling_factor = 100"
    ]
   },
   {
@@ -228,6 +228,119 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### CosmoDC2\n",
+    "\n",
+    "Load CosmoDC2 for reference.  This is the truth table for the input catalog proposals.\n",
+    "It's larger than the Object Table, so we're going to use a similar subsampling plan."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cosmoDC2_cat = GCRCatalogs.load_catalog('cosmoDC2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cosmoDC2_columns = ['ra', 'dec', 'mag_u', 'mag_g', 'mag_r', 'mag_i', 'mag_z', 'mag_y']\n",
+    "max_mag_i = 25\n",
+    "mag_limit_filter = [GCRQuery(f'mag_i < {max_mag_i}')]\n",
+    "cosmoDC2 = pd.DataFrame(cosmoDC2_cat.get_quantities(cosmoDC2_columns,\n",
+    "                                                    filters=[subsample] + mag_limit_filter))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### HSC XMM\n",
+    "from HSC PDR1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hsc_cat = GCRCatalogs.load_catalog('hsc-pdr1-xmm')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Establish some basic cuts intended to yield a galaxy sample with reasonable flux measurements.\n",
+    "basic_cuts = [\n",
+    "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
+    "                       # and was not skipped by the deblender\n",
+    "    GCRQuery('xy_flag == 0'),                                      # Flag for bad centroid measurement\n",
+    "]\n",
+    "\n",
+    "# Define cuts on galaxy properties: currently we simply make a sample limited at i<25.\n",
+    "# This implicitly requires the magnitude to be finite.\n",
+    "max_mag_i = 25\n",
+    "properties_cuts = [\n",
+    "    GCRQuery(f'mag_i_cModel < {max_mag_i}'),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print([c for c in hsc_cat.list_all_quantities() if re.match('mag_', c)])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hsc_filters = ['g', 'r', 'i', 'z']\n",
+    "hsc_columns = ['ra', 'dec']\n",
+    "hsc_columns += [f'mag_{f}' for f in hsc_filters]\n",
+    "hsc_columns += [f'magerr_{f}' for f in hsc_filters]\n",
+    "hsc_columns += [f'mag_{f}_cModel' for f in hsc_filters]\n",
+    "hsc_columns += [f'magerr_{f}_cModel' for f in hsc_filters]\n",
+    "# hsc_columns += [f'Ixx_{f}' for f in hsc_filters]\n",
+    "# hsc_columns += [f'Ixy_{f}' for f in hsc_filters]\n",
+    "# hsc_columns += [f'Iyy_{f}' for f in hsc_filters]\n",
+    "# hsc_columns += [f'psf_fwhm_{f}' for f in hsc_filters]\n",
+    "hsc_columns += ['good', 'extendedness', 'blendedness']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hsc = pd.DataFrame(hsc_cat.get_quantities(hsc_columns,\n",
+    "                                          filters=basic_cuts + properties_cuts))\n",
+    "\n",
+    "# We could of course done this as part of a GCR query.\n",
+    "# But using a query in the DataFrame is how we did the `stars`, `galaxies` selection above, so we'll do it the same way here.\n",
+    "hsc_stars = hsc[hsc['extendedness'] == 0]\n",
+    "hsc_galaxies = hsc[hsc['extendedness'] > 0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Object Density in RA, Dec"
    ]
   },
@@ -267,7 +380,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_ra_dec(cat):\n",
+    "def plot_ra_dec(cat, show_dc2_region=True):\n",
     "    \"\"\"We're just doing this on a rectilinear grid.\n",
     "    We should do a projection, of course, but that distortion is minor in this space.\"\"\"\n",
     "    fig = plt.figure(figsize=(8, 8))\n",
@@ -280,19 +393,20 @@
     "    plt.ylabel('Dec [deg]')\n",
     "    plt.colorbar(shrink=0.5, label='objects / bin')\n",
     "\n",
-    "    # This region isn't quite a polygon.  The sides should be curved.\n",
-    "    wfd_region = Polygon(dc2_run2x_wfd, color='red', fill=False)\n",
-    "    ddf_region = Polygon(dc2_run2x_ddf, color='orange', fill=False)\n",
-    "    ax.add_patch(wfd_region)\n",
-    "    ax.add_patch(ddf_region)\n",
-    "    \n",
-    "    max_delta_ra = dc2_run2x_wfd[3][0] - dc2_run2x_wfd[2][0]\n",
-    "    delta_dec = dc2_run2x_wfd[1][1] - dc2_run2x_wfd[3][1]\n",
-    "    grow_buffer = 0.05\n",
-    "    ax.set_xlim(dc2_run2x_wfd[3][0] + max_delta_ra * grow_buffer,\n",
-    "                dc2_run2x_wfd[2][0] - max_delta_ra * grow_buffer)\n",
-    "    ax.set_ylim(dc2_run2x_wfd[3][1] - delta_dec * grow_buffer,\n",
-    "                dc2_run2x_wfd[1][1] + delta_dec * grow_buffer)"
+    "    if show_dc2_region:\n",
+    "        # This region isn't quite a polygon.  The sides should be curved.\n",
+    "        wfd_region = Polygon(dc2_run2x_wfd, color='red', fill=False)\n",
+    "        ddf_region = Polygon(dc2_run2x_ddf, color='orange', fill=False)\n",
+    "        ax.add_patch(wfd_region)\n",
+    "        ax.add_patch(ddf_region)\n",
+    "\n",
+    "        max_delta_ra = dc2_run2x_wfd[3][0] - dc2_run2x_wfd[2][0]\n",
+    "        delta_dec = dc2_run2x_wfd[1][1] - dc2_run2x_wfd[3][1]\n",
+    "        grow_buffer = 0.05\n",
+    "        ax.set_xlim(dc2_run2x_wfd[3][0] + max_delta_ra * grow_buffer,\n",
+    "                    dc2_run2x_wfd[2][0] - max_delta_ra * grow_buffer)\n",
+    "        ax.set_ylim(dc2_run2x_wfd[3][1] - delta_dec * grow_buffer,\n",
+    "                    dc2_run2x_wfd[1][1] + delta_dec * grow_buffer)"
    ]
   },
   {
@@ -422,6 +536,24 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_ra_dec(cosmoDC2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_ra_dec(hsc, show_dc2_region=False)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -503,7 +635,10 @@
     "    colors = ['umg', 'rmi', 'imz', 'zmy']\n",
     "    ref_color = 'gmr'\n",
     "    for ax, color in zip(axes.flat, colors):\n",
-    "        plot_color_color(cat, ref_color, color, ax=ax)"
+    "        try:\n",
+    "            plot_color_color(cat, ref_color, color, ax=ax)\n",
+    "        except KeyError:\n",
+    "            continue"
    ]
   },
   {
@@ -538,6 +673,24 @@
    "outputs": [],
    "source": [
     "plot_four_color_color(galaxies)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_four_color_color(cosmoDC2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_four_color_color(hsc)"
    ]
   },
   {
@@ -598,7 +751,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Compare to HSC galaxy density, courtesy of Rachel Mandelbaum"
+    "#### Compare to HSC and CosmocDC galaxy densities\n",
+    "\n",
+    "Test inspired by Rachel Mandelbaum"
    ]
   },
   {
@@ -745,12 +900,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "area_cosmoDC2 = calculate_area(cosmoDC2)\n",
+    "print(f'CosmoDC2 area: {area_cosmoDC2:0.2f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "num_den_dc2 = sampling_factor * len(galaxies) / area_dc2\n",
     "num_den_hsc = len(hsc) / area_hsc\n",
+    "num_den_cosmoDC2 = len(cosmoDC2) / area_cosmoDC2\n",
     "\n",
     "# Change default expression to 1/arcmin**2\n",
     "num_den_dc2 = num_den_dc2.to(1/u.arcmin**2)\n",
-    "num_den_hsc = num_den_hsc.to(1/u.arcmin**2)"
+    "num_den_hsc = num_den_hsc.to(1/u.arcmin**2)\n",
+    "num_den_cosmoDC2 = num_den_cosmoDC2.to(1/u.arcmin**2)"
    ]
   },
   {
@@ -767,10 +934,11 @@
     "plt.figure(figsize=(8, 8))\n",
     "nbins = 50\n",
     "mag_range = [20, max_mag_i]\n",
-    "data_to_plot = [galaxies['mag_i'], hsc['mag_i']]\n",
+    "data_to_plot = [galaxies['mag_i'], cosmoDC2['mag_i'], hsc['mag_i']]\n",
     "labels_to_plot = [\n",
     "    f'Run 2.1i object catalog: {num_den_dc2.value:.1f} {num_den_dc2.unit:fits}',\n",
-    "    f'HSC XMM field: {num_den_hsc.value:.1f} {num_den_hsc.unit:fits}'\n",
+    "    f'Cosmo DC2 truth: {num_den_cosmoDC2.value:.1f} {num_den_cosmoDC2.unit:fits}',\n",
+    "    f'HSC XMM field: {num_den_hsc.value:.1f} {num_den_hsc.unit:fits}',\n",
     "]\n",
     "plt.hist(data_to_plot, nbins, range=mag_range, histtype='step',\n",
     "         label=labels_to_plot, linewidth=2.0, density=True)\n",

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Inspection of DC2 Run 2.1i Object Table \n",
     "### Michael Wood-Vasey (@wmwv)\n",
-    "### Last Verified to Run: 2019-07-12\n",
+    "### Last Verified to Run: 2019-07-16\n",
     "\n",
     "Inspect the Run 2.1i DR1 Object Table for DR1*\n",
     "\n",
@@ -110,7 +110,7 @@
    "source": [
     "# Sampling must be an positive integer.\n",
     "# To reduce subsequent arithmetic demands on your brain I would recommend picking a power of ten.\n",
-    "sampling_factor = 10"
+    "sampling_factor = 1"
    ]
   },
   {
@@ -803,7 +803,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hsc = pd.DataFrame(hsc_cat.get_quantities(['extendedness', 'ra', 'dec', 'mag_i', 'mag_i_cModel'], filters=basic_cuts + properties_cuts))"
+    "hsc = pd.DataFrame(hsc_cat.get_quantities(['extendedness', 'ra', 'dec', 'mag_i', 'mag_i_cModel'],\n",
+    "                                          filters=basic_cuts + properties_cuts))"
    ]
   },
   {

--- a/validation/validate_dc2_run2.1i_object_table.ipynb
+++ b/validation/validate_dc2_run2.1i_object_table.ipynb
@@ -10,9 +10,9 @@
     "\n",
     "Inspect the Run 2.1i DR1 Object Table for DR1*\n",
     "\n",
-    "This notebook is more qualitative rather than quantitative validation.  It should eventually grow to include goals for the visualizations and numerical thresholds for specific quantities.\n",
+    "This notebook is more qualitative rather than quantitative validation.  The analysis contained here should eventually grow beyond the confines of a notebook to include goals for the visualizations and numerical thresholds for specific quantities.\n",
     "\n",
-    "1. Make density plots (e.g., `hexbin`, `hist2d`, `datashader`) of\n",
+    "1. Make 2D density plots (e.g., `hexbin`, `hist2d`, `datashader`) of\n",
     "    - ra, dec\n",
     "    - u-g, g-r\n",
     "    - r-i, g-r\n",
@@ -132,7 +132,7 @@
    "metadata": {},
    "source": [
     "For further reduction of the sample loaded into the memory we construct  some subsampling filters.\n",
-    "The final digits of the objectId should be evenly distributed across the sample so we can\n",
+    "The final digits of the `objectId` should be evenly distributed across the sample so we can\n",
     "extract subsample by using modulo to look at last digits."
    ]
   },


### PR DESCRIPTION
Compare number density and areal density to CosmoDC2

Does not do matching.  Just compares populations things like RA, Dec distribution and number density with magnitude.

Rendered version available at
https://github.com/LSSTDESC/DC2-analysis/blob/rendered/validation/validate_dc2_run2.1i_object_table.ipynb

If that doesn't load for you through the GitHub render, clone the `DC2-analysis` repo and check out the `rendered` branch locally.

fix #101 