### PR TITLE
update object photoz notebook

### DIFF
--- a/tutorials/object_gcr_4_photoz.ipynb
+++ b/tutorials/object_gcr_4_photoz.ipynb
@@ -4,21 +4,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# DC2 Object Catalog Run1.2i GCR tutorial -- Part IV: accessing photo-z\n",
+    "# DC2 Object Catalog Run2.2i GCR tutorial -- Part IV: accessing photo-z\n",
     "\n",
     "Owners: **Yao-Yuan Mao [@yymao](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@yymao)**, \n",
     "        **Sam Schmidt [@sschmidt23](https://github.com/LSSTDESC/DC2-analysis/issues/new?body=@sschmidt23)**\n",
     "\n",
-    "Last Verifed to Run: **2019-02-25** (by @yymao)\n",
+    "Last Verifed to Run: **2020-06-09** (by @sschmidt23)\n",
     "\n",
-    "This notebook will show you how to access the \"add-on\" columns that provide the photometric redshift (photo-z) information for the DC2 Object Catalog (Run 1.2i). \n",
+    "This notebook will show you how to access the \"add-on\" columns that provide the photometric redshift (photo-z) information for the DC2 Object Catalog (Run 2.2i). \n",
     "\n",
     "__Learning objectives__: After going through this notebook, you should be able to:\n",
     "  1. Load and efficiently access a DC2 object catalog (+ photo-z) with the GCR\n",
     "  2. Understand how the photo-z data are stored / represented\n",
     "  3. Look at an example of galaxy photo-z distributions\n",
     "  \n",
-    "__Logistics__: This notebook is intended to be run through the JupyterHub NERSC interface available here: https://jupyter-dev.nersc.gov. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter-dev+at+NERSC\n",
+    "__Logistics__: This notebook is intended to be run through the Jupyter Lab NERSC interface available here: https://jupyter.nersc.gov/. To setup your NERSC environment, please follow the instructions available here: https://confluence.slac.stanford.edu/display/LSSTDESC/Using+Jupyter+at+NERSC\n",
     "\n",
     "__Other notes__: \n",
     "If you restart your kernel, or if it automatically restarts for some reason, all imports and variables will become undefined so, you will have to re-run everything."
@@ -42,7 +42,8 @@
    "outputs": [],
    "source": [
     "import GCRCatalogs\n",
-    "from GCR import GCRQuery"
+    "from GCR import GCRQuery\n",
+    "GCRCatalogs.__version__"
    ]
   },
   {
@@ -51,9 +52,7 @@
    "source": [
     "## Load the catalog\n",
     "\n",
-    "Loading the object catalog with photo-z add-on. The catalog name is `dc2_object_run1.2i_with_photoz`. \n",
-    "\n",
-    "**Note**: if you need more quantities (including those not in DPDD), then use `dc2_object_run1.2i_all_columns_with_photoz` instead.\n",
+    "Loading the object catalog with photo-z add-on. The catalog name is `dc2_object_run2.2i_with_photoz`. \n",
     "\n",
     "It takes a few seconds for the catalog instance to initiate."
    ]
@@ -64,7 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = GCRCatalogs.load_catalog('dc2_object_run1.2i_with_photoz')"
+    "cat = GCRCatalogs.load_catalog('dc2_object_run2.2i_dr3_with_photoz')\n"
    ]
   },
   {
@@ -73,15 +72,23 @@
    "source": [
     "## Photo-z access methods\n",
     "\n",
-    "The photo-z infomation can be accessed in two ways:\n",
+    "There are several photo-z related quantities available in the catalog, a summary of which can be found on this Confluence page:\n",
+    "https://confluence.slac.stanford.edu/display/LSSTDESC/List+of+available+DC2+catalogs+created+by+PhotoZ\n",
     "\n",
-    "1. As a single column `photoz_mode` that has the mode value (z_peak), and\n",
-    "2. As a single multi-dimensional column `photoz_pdf` \n",
-    "   (i.e., when accessing this column, you get a 2D array (objects x PDF values) instead of a 1D array). \n",
-    "   Note that the column contains only the PDF values, not the bin center values. \n",
-    "   The PDF bin centers are stored in a catalog attribute named `photoz_pdf_bin_centers`. \n",
+    "There are photo-z estimates in the form of both a single number \"point estimate\" for each galaxy, as well as a 1D redshift probability density function (PDF) representing the posterior probability of the galaxy being at a given redshift calculated on a specific redshift grid.\n",
     "\n",
-    "We will demonstrate both access methods in detail. You can notice that all the photo-z columns have a prefix of `photoz_`. \n",
+    "There are multiple single point estimates:\n",
+    "1. `photoz_mode`: the mode of the redshift PDF, the highest peak of the posterior probability\n",
+    "2. `photoz_mean`: the weighted mean of the redshift PDF.\n",
+    "3. `photoz_median`: the redshift where the redshift CDF is equal to 0.5.\n",
+    "\n",
+    "The redshift pdf is stored in the multi-valued column `photoz-pdf`.  The grid of redshifts at which the posterior probability is evaluated is stored in the catalog with the special attribute of `photoz_pdf_bin_centers`.  You can access this attribute for catalog cat with something like `zgrid = cat.photoz_pdf_bin_centers`\n",
+    "\n",
+    "There are three additional columns that can be used as various quality flags:\n",
+    "1. `photoz_odds` (see Benitez 2000) is a measure of the integrated amount or probaility within a fixed distance around `photoz_mode`.  If the redshift posterior is single peaked and narrow this number will be close to 1.0, if the posterior is multi-peaked and/or broad it is likely to be smaller.  Thus, high values of `photoz_odds` can be used as an indicator of photo-z quality.\n",
+    "2. `photoz_mode_ml_red_chi2` is the reduced chi-squared value for the maximum likelihood estimate of the best fit template at the photo-z mode.  If this chi-squared value is very large, it indicates that none of the SED templates employed by the photo-z code were good fits to the observed colors, and thus the redshift may be suspect. High values may also occur for very bright galaxies where photometric errors are small and thus chi-squared values can grow large.\n",
+    "\n",
+    "We will demonstrate access methods for several of these quantities in detail. You can notice that all the photo-z columns have a prefix of `photoz_`. \n",
     "\n",
     "Let's first make sure that these columns are indeed available. "
    ]
@@ -100,7 +107,7 @@
    "metadata": {},
    "source": [
     "Let's now try access the photo-z data! Everything you already about the GCR access of object catalogs will still apply. \n",
-    "Including the use of `filters` and `native_filters` (`native_filters` is used for selecting tracts mostly). "
+    "Including the use of `filters` and `native_filters` (`native_filters` is used for selecting tracts mostly). We will access the single tract 4850."
    ]
   },
   {
@@ -121,9 +128,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, if you want to make a plot of the PDF, it might be easier to access the `photoz_pdf` column. Note that it is a multi-dimensional column, so use with care!\n",
+    "Now, if you want to make a plot of the PDF for a galaxy or galaxies, you will need to access the `photoz_pdf` column. Note that each entry stores an array, so use with care!\n",
     "\n",
-    "As an example, let's just load one patch (using the `return_iterator` feature) of the full PDFs and also peak values at the same time:"
+    "As an example, let's just load one tract (using the `return_iterator` feature) of the full PDFs and also peak and mean values at the same time.  The first few tracts have very few objects, some of which are only detected in a handful of bands, so we'll load the 14th tract:"
    ]
   },
   {
@@ -132,14 +139,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = next(cat.get_quantities(['photoz_pdf', 'photoz_mode'], return_iterator=True))"
+    "xcat = cat.get_quantities(['photoz_pdf', 'photoz_mode', 'photoz_mean'], return_iterator=True)\n",
+    "for i in range(14):\n",
+    "    data = next(xcat)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are 72 objects in this patch, and there are 101 bins in the photo-z PDF, so this 2D array has a shape of (72, 101). Note how the 2D array is oriented."
+    "There are 684,634 objects in this tract, and there are 301 bins in the photo-z PDF. The photoz_pdf data is a 1D array has a shape of (684634,), *but* each entry stores an array of 301 values. "
    ]
   },
   {
@@ -152,20 +161,13 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print (data['photoz_mode'][:10])"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's plot 10 PDFs. The PDFs were evaluated on a set grid of redshift values.  For run1.2 this grid only extended to z=1.0, as the protoDC2 catalog only covered this range, for future releases the photo-z range will expand to higher redshift. <br>\n",
-    "To get the array of bin center values, you can access the `pz_pdf_bin_centers` attribute. "
+    "Now, let's plot 10 example PDFs.  We will plot every 100th PDF as this shows a bit more variety in PDF shapes.\n",
+    "The PDFs were evaluated on a set grid of redshift values.  For run2.2 this grid extends to z=3.0.<br>\n",
+    "To get the array of bin center values, you can access the `photoz_pdf_bin_centers` attribute, as demonstrated below.  \n",
+    "We overplot the `photoz_mode` and `photoz_mean` values as well."
    ]
   },
   {
@@ -174,19 +176,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(5, 2, figsize=(11,14))\n",
-    "for pdf, z_peak, ax_this in zip(data['photoz_pdf'], data['photoz_mode'], ax.flat):\n",
-    "    l = ax_this.plot(cat.photoz_pdf_bin_centers, pdf);\n",
-    "    ax_this.axvline(z_peak, color=l[0].get_color(), ls=':', lw=1);\n",
+    "fig, ax = plt.subplots(5, 2, figsize=(12,16))\n",
+    "for pdf, z_peak, z_mean, ax_this in zip(data['photoz_pdf'][::100], data['photoz_mode'][::100],\n",
+    "                                        data['photoz_mean'][::100], ax.flat):\n",
+    "    l = ax_this.plot(cat.photoz_pdf_bin_centers, pdf,label='p(z)');\n",
+    "    ax_this.axvline(z_peak, color=l[0].get_color(), ls=':', lw=1,label='photoz_mode');\n",
+    "    ax_this.axvline(z_mean,color='r',ls='--',lw=1,label='photoz_mean');\n",
     "    ax_this.set_xlabel('$z$');\n",
-    "    ax_this.set_ylabel('$p(z)$');"
+    "    ax_this.set_ylabel('$p(z)$');\n",
+    "    ax_this.legend(loc='upper right')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that these PDFs only go to $z=1$. This is because the photo-z catalog presented here is just a test catalog, and Run 1.2x is using protoDC2, which only contains galaxies up to $z=1$. "
+    "We see that `photoz_mode` does, indeed, correspond to the mode/peak of the posterior.  `photoz_mean` lies at the weighted mean redshift.  For multi-peaked posteriors this position can actually be in a location of relatively low probability between two peaks.  We see a variety of PDF shapes: narrow unimodal; broad and/or tailed; and multimodal distributions.  This is due to a combination of the galaxy's observed colors and magnitude uncertainties."
    ]
   },
   {
@@ -211,11 +216,11 @@
     "    GCRQuery((np.isfinite, 'mag_i')), # Select objects that have i-band magnitudes\n",
     "    GCRQuery('clean'), # The source has no flagged pixels (interpolated, saturated, edge, clipped...) \n",
     "                       # and was not skipped by the deblender\n",
-    "    GCRQuery('snr_i_cModel > 20'),    # SNR > 10\n",
+    "    GCRQuery('snr_i_cModel > 20'),    # SNR > 20\n",
     "    GCRQuery('snr_r_cModel > 20'),\n",
     "    GCRQuery('snr_g_cModel > 20'),\n",
-    "    GCRQuery('mag_i_cModel < 22'),  # cModel imag brighter than 22\n",
-    "    GCRQuery('mag_i_cModel > 20')  # cModel imag fainter than 20 (exclude super bright objects)\n",
+    "    GCRQuery('mag_i_cModel < 23'),    # cModel imag brighter than 23\n",
+    "    GCRQuery('mag_i_cModel > 20')     # cModel imag fainter than 20 (exclude super bright objects)\n",
     "]"
    ]
   },
@@ -236,6 +241,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can construct a rough estimate for the N(z) by summing the individual galaxy PDFs in `photoz_pdf`, and compare the results of this sum to the histogram of the single point `photoz_mode` values."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -250,10 +262,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig = plt.figure(figsize=(12,8))\n",
     "plt.hist(data['photoz_mode'], 100, label=\"photo-z mode\");\n",
-    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf,label=\"summed $p(z)$\");\n",
+    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf*3.,label=\"summed $p(z)$\",lw=2,c='r');\n",
     "plt.xlabel(\"redshift\");\n",
-    "plt.legend(loc='upper left');"
+    "plt.legend(loc='upper right');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `photoz_mode` and `photoz_pdf` shapes roughly agree, though we see a more smooth distribution with the full posteriors.  We also see a reduction of the anomalous high redshift features that appear with `photoz_mode`, where the posteriors are multi-peaked: using the full PDFs properly puts some of this probability at lower redshift rather than assigning to the single high redshift value.\n",
+    "\n",
+    "Let's also plot a color-color diagram and color code by the `photoz_mode` value"
    ]
   },
   {
@@ -262,15 +284,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig = plt.figure(figsize=(10,8))\n",
     "plt.scatter(data['mag_g_cModel'] - data['mag_r_cModel'],\n",
     "            data['mag_r_cModel'] - data['mag_i_cModel'],\n",
-    "            c=data['photoz_mode'], s=4, vmin=0, vmax=1);\n",
+    "            c=data['photoz_mode'], s=4, vmin=0, vmax=2.5,cmap='inferno');\n",
     "\n",
     "plt.xlim(-1, 3);\n",
     "plt.ylim(-0.5, 2);\n",
-    "plt.xlabel('$g-r$');\n",
-    "plt.ylabel('$r-i$');\n",
-    "plt.colorbar(label='$z$');\n",
+    "plt.xlabel('$g-r$',fontsize=18);\n",
+    "plt.ylabel('$r-i$',fontsize=18);\n",
+    "plt.colorbar(label='photoz_mode');\n",
     "\n",
     "# Food for thought: Look at how the photo-z values are distributed in this color-color space. Is this behavior expected?"
    ]
@@ -279,14 +302,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see a strong correlation between redshift and position in color space, however the colors are determined by both the SED shape and redshift, so we also see degenerate areas, particularly at the blue end near color = 0.0 where low and high redshift solutions are close in color space."
+    "We can see a strong correlation between redshift and position in color space, however the colors are determined by both the SED shape and redshift, so we also see degenerate areas, particularly at the blue end near color = 0.0 where low and high redshift solutions are close in the observed color space.  "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's also examine a tomographic slice selected in terms of photoz_mode:"
+    "Now let's examine a tomographic slice selected in terms of photoz_mode:"
    ]
   },
   {
@@ -305,10 +328,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.hist(data['photoz_mode'][bin_cut], 100, label=r'photo-z mode, $0.6 < z_{\\rm mode} < 0.8$');\n",
-    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf_bin, label=r'summed $p(z)$, $0.6 < z_{\\rm mode} < 0.8$');\n",
-    "plt.xlabel(\"redshift\");\n",
-    "plt.legend(loc='upper left');"
+    "fig = plt.figure(figsize=(10,5))\n",
+    "plt.hist(data['photoz_mode'][bin_cut], bins = np.arange(0.0,3.01,.01), label=r'photo-z mode, $0.6 < z_{\\rm mode} < 0.8$');\n",
+    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf_bin,c='r', label=r'summed $p(z)$, $0.6 < z_{\\rm mode} < 0.8$');\n",
+    "plt.xlabel(\"redshift\",fontsize=15);\n",
+    "plt.ylabel(\"Number\",fontsize=15)\n",
+    "plt.legend(loc='upper right');\n",
+    "plt.xlim(0.25,1.25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that, while the `photoz_mode` values have been selected in a narrow range, the summed PDF values show \"tails\" that extend beyond the nominal bin.  This illustrates the uncertain values in photo-z estimates that are not easily summed up in a single number like `photoz_mode`.\n",
+    "\n",
+    "Let's look at the location of galaxies within this tomographic bin in color space:"
    ]
   },
   {
@@ -317,30 +352,105 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "fig = plt.figure(figsize=(10,8))\n",
+    "plt.scatter(data['mag_g_cModel'] - data['mag_r_cModel'],\n",
+    "            data['mag_r_cModel'] - data['mag_i_cModel'],\n",
+    "            c='k',s=2,alpha=0.8,label='all galaxies');\n",
     "plt.scatter(data['mag_g_cModel'][bin_cut] - data['mag_r_cModel'][bin_cut],\n",
     "            data['mag_r_cModel'][bin_cut] - data['mag_i_cModel'][bin_cut],\n",
-    "            c=data['photoz_mode'][bin_cut], s=4, vmin=0, vmax=1);\n",
+    "            c=data['photoz_mode'][bin_cut], s=10, vmin=0, vmax=2.5, cmap='inferno',\n",
+    "            label='$0.6<z\\_mode<0.8$');\n",
     "\n",
     "plt.xlim(-1, 3);\n",
     "plt.ylim(-0.5, 2);\n",
-    "plt.xlabel('$g-r$');\n",
-    "plt.ylabel('$r-i$');\n",
-    "plt.colorbar(label='$z$');"
+    "plt.xlabel('$g-r$',fontsize=18);\n",
+    "plt.ylabel('$r-i$',fontsize=18);\n",
+    "plt.colorbar(label='photoz_mode');\n",
+    "plt.legend(loc='upper left')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We see that that distributions of mode values versus stacked p(z) differ slightly, particularly in extended \"wings\" that extend beyond the bin boundaries.  We also see that the range of colors for this tomographic bin is restricted compared to the overall distribution.  Users may want to modify bin definitions by looking at color distributions to avoid common degeneracies."
+    "We see that the range of colors for this tomographic bin is restricted compared to the overall distribution.  Users may want to modify bin definitions by looking at color distributions to avoid common degeneracies.  As an example of such a degenracy, let's attempt to select galaxies with `photoz_mode` between 2.0 and 2.5:"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bin_cut = GCRQuery('photoz_mode > 2.0', 'photoz_mode < 2.5').mask(data)\n",
+    "sumpdf_bin = np.sum(data['photoz_pdf'][bin_cut],axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(10,5))\n",
+    "plt.hist(data['photoz_mode'][bin_cut], bins = np.arange(0.0,3.01,.01), label=r'photo-z mode, $0.6 < z_{\\rm mode} < 0.8$');\n",
+    "plt.plot(cat.photoz_pdf_bin_centers, sumpdf_bin,c='r', label=r'summed $p(z)$, $0.6 < z_{\\rm mode} < 0.8$');\n",
+    "plt.xlabel(\"redshift\",fontsize=18);\n",
+    "plt.ylabel(\"Number\",fontsize=18)\n",
+    "plt.legend(loc='upper right');\n",
+    "#plt.xlim(0.25,1.25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the sum of the PDFs indicates that there are potential degenerate solutions at both z~0.2 and 1.4 with non-negligible probability.  We also see that the relative height fo the two peaks in the 2<z<2.5 bin is rather different between the `photoz_mode` histogram and the sum of `photoz_pdf`.  Let's plot the colors of these galaxies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(10,8))\n",
+    "plt.scatter(data['mag_g_cModel'] - data['mag_r_cModel'],\n",
+    "            data['mag_r_cModel'] - data['mag_i_cModel'],\n",
+    "            c='k',s=2,alpha=0.8,label='all galaxies');\n",
+    "plt.scatter(data['mag_g_cModel'][bin_cut] - data['mag_r_cModel'][bin_cut],\n",
+    "            data['mag_r_cModel'][bin_cut] - data['mag_i_cModel'][bin_cut],\n",
+    "            c=data['photoz_mode'][bin_cut], s=10, vmin=0, vmax=2.5, cmap='inferno',\n",
+    "            label='$2.0<z\\_mode<2.5$');\n",
+    "\n",
+    "plt.xlim(-1, 3);\n",
+    "plt.ylim(-0.5, 2);\n",
+    "plt.xlabel('$g-r$',fontsize=18);\n",
+    "plt.ylabel('$r-i$',fontsize=18);\n",
+    "plt.colorbar(label='photoz_mode');\n",
+    "plt.legend(loc='upper left')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that galaxies with `photoz_mode` between 2.0 and 2.5 reside in several areas of color space, including an area of potential degeneracy near g-r ~ r-i ~ 0 where galaxies at both low and high redshift reside.  This is not uncommon for high redshift galaxies, which tend to have very blue, power-law-like SEDs, which tend to have blue colors at nearly all redshifts, and are thus prone to degeneracies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "desc-python",
+   "display_name": "desc-python-dev",
    "language": "python",
-   "name": "desc-python"
+   "name": "desc-python-dev"
   },
   "language_info": {
    "codemirror_mode": {
@@ -352,9 +462,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR addresses issue #131 on updating the object_gcr_4_photoz.ipynb notebook.  The notebook currently runs on desc-python-dev kernel due to a name change in a photo-z variable that happens in gcr-catalogs v0.18.0, but should work fine on desc-python in a few days.  I updated some of the descriptions to include a few new variables that were not included in run1.2i, and added a couple of extra plots and some explanatory text.  The notebook should only take ~10-20 seconds to run.